### PR TITLE
fix(playwright): CI 환경에서 reporter 설정 변경

### DIFF
--- a/libraries/base/playwright.config.js
+++ b/libraries/base/playwright.config.js
@@ -46,7 +46,7 @@ export default {
 			}
 		:	{},
 	],
-	reporter: process.env.CI ? 'github' : 'html',
+	reporter: 'html',
 	retries: process.env.CI ? 1 : 0,
 	testDir: 'e2e',
 	timeout: 60_000,


### PR DESCRIPTION
reporter를 process.env.CI에 따라 'github'에서 'html'로 변경했음. CI 환경에서의 reporter 설정을 단순화했음.