### PR TITLE
feat(ci): 액션 워크플로우에 토큰 추가

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          token: ${{ secrets.TOKEN1 }}
 
       - name: Cache turbo build setup
         uses: actions/cache@v4

--- a/.github/workflows/check_lint.yml
+++ b/.github/workflows/check_lint.yml
@@ -24,6 +24,9 @@ jobs:
       # 저장소 코드 체크아웃
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          token: ${{ secrets.TOKEN1 }}
 
       - name: Cache turbo build setup
         uses: actions/cache@v4


### PR DESCRIPTION
GitHub Actions 워크플로우에 토큰을 추가했습니다. 이를 통해 저장소 코드를 체크아웃할 때 깊이 제한을 2로 설정할 수 있습니다. 이는 빌드 및 테스트 프로세스를 더 효율적으로 만들 것입니다.