### PR TITLE
feat(ci): 이미지 압축 및 링크 검사 워크플로우 개선

### DIFF
--- a/.github/workflows/compress_images.yml
+++ b/.github/workflows/compress_images.yml
@@ -1,6 +1,8 @@
 name: Compress Images
 on:
   pull_request:
+    types:
+      - labeled
     # Run Image Actions when JPG, JPEG, PNG or WebP files are added or changed.
     # See https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onpushpull_requestpaths for reference.
     paths:
@@ -11,7 +13,7 @@ on:
 jobs:
   build:
     # Only run on Pull Requests within the same repository, and not from forks.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: (github.event.pull_request.head.repo.full_name == github.repository) && (contains(github.event.pull_request.labels.*.name, 'mutation-completed'))
     name: calibreapp/image-actions
     permissions: write-all
     runs-on: ubuntu-latest

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     name: Linkspector
     runs-on: ubuntu-latest
+    if: "contains(github.event.pull_request.labels.*.name, 'mutation-completed')"
+
     steps:
       - uses: actions/checkout@v4
       - name: Run linkspector


### PR DESCRIPTION
이 커밋에서는 다음과 같은 변경 사항이 있습니다:

1. `.github/workflows/link_check.yml` 파일에서 `if` 조건을 추가하여 `mutation-completed` 라벨이 있는 Pull Request에만 링크 검사 작업이 실행되도록 했습니다. 이를 통해 불필요한 작업 실행을 방지할 수 있습니다.

2. `.github/workflows/compress_images.yml` 파일에서 `if` 조건을 수정하여 `mutation-completed` 라벨이 있는 Pull Request에만 이미지 압축 작업이 실행되도록 했습니다. 또한 `on.pull_request.types`를 추가하여 라벨이 추가되는 경우에도 워크플로우가 실행되도록 했습니다.

이러한 변경을 통해 CI/CD 파이프라인의 효율성을 높이고, 불필요한 작업 실행을 방지할 수 있습니다.