### PR TITLE
feat: add GitHub Actions workflow and README updates

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,0 +1,38 @@
+name: Link Check
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  pull-requests: write # Necessary to comment on PRs
+  issues: read # Necessary to read issue commentsds
+  contents: read # Necessary to access the repo content
+
+jobs:
+  build:
+    name: Linkspector
+    runs-on: ubuntu-latest
+    if: "contains(github.event.pull_request.labels.*.name, 'mutation-completed')"
+
+    steps:
+      - name: Half-year calendar
+        uses: lowlighter/metrics@latest
+        with:
+          filename: metrics.plugin.isocalendar.halfyear.svg
+          token: ${{ secrets.TOKEN1 }}
+          base: ''
+          plugin_isocalendar: yes
+
+      - name: Recent activity charts
+        uses: lowlighter/metrics@latest
+        with:
+          filename: metrics.plugin.habits.charts.svg
+          token: ${{ secrets.TOKEN1 }}
+          base: ''
+          plugin_habits: yes
+          plugin_habits_facts: yes
+          plugin_habits_charts: yes
+          config_timezone: Asia/Seoul

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+![halfyear](./metrics.plugin.isocalendar.halfyear.svg)
+![charts](./metrics.plugin.habits.charts.svg)


### PR DESCRIPTION
    이 커밋에서는 다음과 같은 변경사항이 있습니다:

    1. `.github/workflows/metrics.yml` 파일을 추가하여 GitHub Actions 워크플로를 구현했습니다. 이 워크플로는 풀 리퀘스트에 'mutation-completed' 라벨이 붙은 경우 실행되며, 다음과 같은 작업을 수행합니다:
        - 반년 달력 차트를 생성하여 `metrics.plugin.isocalendar.halfyear.svg` 파일로 저장
        - 최근 활동 차트를 생성하여 `metrics.plugin.habits.charts.svg` 파일로 저장

    2. `README.md` 파일에 생성된 두 개의 SVG 이미지를 추가했습니다.

    이 변경사항은 프로젝트에 GitHub Actions 기반의 자동화된 메트릭 생성 기능을 추가하고, 해당 메트릭을 README에 표시하여 프로젝트의 활동 상황을 시각적으로 보여주기 위해 수행되었습니다.