### PR TITLE
feat(github-action): 비밀번호 스캔 워크플로우 추가

### DIFF
--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -1,0 +1,18 @@
+on:
+  pull_request:
+    types:
+      - labeled
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: "contains(github.event.pull_request.labels.*.name, 'mutation-completed')"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Secret Scanning
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --results=verified,unknown

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -1,9 +1,18 @@
+name: Check Secrets
+
 on:
   pull_request:
     types:
       - labeled
+
+permissions:
+  pull-requests: write # Necessary to comment on PRs
+  issues: read # Necessary to read issue commentsds
+  contents: read # Necessary to access the repo content
+
 jobs:
-  test:
+  check-secrets:
+    name: Check Secrets
     runs-on: ubuntu-latest
     if: "contains(github.event.pull_request.labels.*.name, 'mutation-completed')"
 


### PR DESCRIPTION
이 커밋에서는 GitHub Actions 워크플로우를 추가하여 풀 리퀘스트에 포함된 비밀번호를 스캔하는 기능을 구현했습니다. 

주요 변경 사항은 다음과 같습니다:

1. `on.pull_request.types` 필드를 추가하여 `labeled` 이벤트에 대해서만 워크플로우를 실행하도록 설정했습니다. 이를 통해 `mutation-completed` 라벨이 붙은 풀 리퀘스트에 대해서만 비밀번호 스캔이 수행됩니다.
2. `trufflesecurity/trufflehog` 액션을 사용하여 비밀번호 스캔을 수행하도록 구현했습니다. `extra_args` 옵션을 통해 `verified`와 `unknown` 결과만 출력되도록 설정했습니다.

이 변경 사항은 코드베이스의 보안을 강화하고, 비밀번호 노출 위험을 사전에 방지하기 위해 추가되었습니다.