### PR TITLE
chore(workflow): mutation-completed 라벨이 있는 경우에만 자동 병합 실행

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -40,7 +40,7 @@ jobs:
       contents: write
       pull-requests: write
 
-    if: always()
+    if: always() && contains(github.event.pull_request.labels.*.name, 'mutation-completed')
     steps:
       - name: Remove mutation-completed Label
         if: always()


### PR DESCRIPTION
mutation-completed 라벨이 있는 경우에만 자동 병합 작업을 실행하도록 변경했음. 이를 통해 불필요한 자동 병합 작업을 방지할 수 있음.