### PR TITLE
chore(dependabot): 업데이트 주기를 주간에서 일일로 변경

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
   - package-ecosystem: npm # See documentation for possible values
     directory: / # Location of package manifests
     schedule:
-      interval: weekly
+      interval: daily
     labels:
       - dependabot


### PR DESCRIPTION
Dependabot 설정 파일에서 업데이트 주기를 주간에서 일일로 변경했습니다. 이를 통해 보안 및 버그 수정 사항을 보다 신속하게 반영할 수 있습니다.