### PR TITLE
feat(auto-merge): Dependabot 메타데이터 가져오기 추가

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -11,8 +11,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-
     if: "contains(github.event.pull_request.labels.*.name, 'mutation-completed') && !contains(github.event.pull_request.labels.*.name, 'dependabot')"
+
     steps:
       - uses: reitermarkus/automerge@v2
         with:
@@ -25,18 +25,20 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-
     if: "contains(github.event.pull_request.labels.*.name, 'mutation-completed') && contains(github.event.pull_request.labels.*.name, 'dependabot')"
-    steps:
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
-        with:
-          target: patch
-          github-token: ${{ secrets.TOKEN1 }}
 
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
         with:
-          target: minor
-          github-token: ${{ secrets.TOKEN1 }}
+          github-token: '${{ secrets.TOKEN1 }}'
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.TOKEN1}}
 
   remove-mutation-completed-label:
     needs: [automerge, automerge-dependabot]
@@ -44,8 +46,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-
     if: always() && contains(github.event.pull_request.labels.*.name, 'mutation-completed')
+
     steps:
       - name: Remove mutation-completed Label
         if: always()


### PR DESCRIPTION
Dependabot PR의 메타데이터를 가져오는 작업을 추가했음. 
이제 PR의 업데이트 유형에 따라 자동 병합을 활성화함. 
기존의 자동 병합 작업을 개선하여, Dependabot의 패치 및 마이너 업데이트를 처리할 수 있도록 변경했음. 
또한, 불필요한 라벨 제거 작업을 위한 조건을 추가했음.