### PR TITLE
feat(storybook): tailwindcss2 제거 및 svelte() 수정

### DIFF
--- a/storybook/vite.config.js
+++ b/storybook/vite.config.js
@@ -1,15 +1,11 @@
-import { defineConfig } from 'vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import tailwindcss from '@tailwindcss/vite'
-import tailwindcss2 from '@tailwindcss/postcss'
+import { defineConfig } from 'vite'
+import tsconfigPaths from 'vite-tsconfig-paths'
 // https://vitejs.dev/config/
 export default defineConfig({
 	css: {
 		devSourcemap: true,
-		postcss: {
-			plugins: [tailwindcss2()],
-		},
 	},
 	// Fix: storybook 업데이트 하면서 svelte() 이거 sveltekit으로 바꾸고, base/vite.config.js 에서 import 한 거 사용하게 만들기
 	plugins: [svelte(), tsconfigPaths(), tailwindcss()],


### PR DESCRIPTION
tailwindcss2 플러그인을 제거하고 tailwindcss로 변경했음.  
svelte()를 sveltekit으로 수정하여 base/vite.config.js에서 import한 것을 사용하도록 했음.  
devSourcemap을 true로 설정하여 개발 중 소스 맵을 활성화했음.