### PR TITLE
feat(rules): XState 및 CSS 규칙 수정

### DIFF
--- a/.cursor/rules/css.mdc
+++ b/.cursor/rules/css.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: **/*.css,**/*.svelte
+description: Wheneven handling CSS
+globs: 
 alwaysApply: false
 ---
 Use predefined CSS variables when possible:

--- a/.cursor/rules/xstate.mdc
+++ b/.cursor/rules/xstate.mdc
@@ -1,6 +1,6 @@
 ---
 description: 
-globs: 
+globs: *.xstate.*
 alwaysApply: false
 ---
 Always use the latest version: [XState.md](mdc:.cursor/docs/XState.md)


### PR DESCRIPTION
XState 규칙에서 globs 항목을 수정하여 *.xstate.* 패턴을 추가했음.  
CSS 규칙에서 description을 "Wheneven handling CSS"로 변경했음.  
이 변경은 규칙의 명확성을 높이고, 사용자가 더 쉽게 이해할 수 있도록 하기 위함임.