### PR TITLE
feat: dragDrop 인터랙션 처리 개선 및 unmapper 추가

### DIFF
--- a/.cursor/prompts/linter-error-fix.md
+++ b/.cursor/prompts/linter-error-fix.md
@@ -25,4 +25,4 @@ The inclusion of these instructions signifies that your primary mission is to re
    4. **Proposed Solution & Improvement:** Describe the step-by-step changes you will make to the code to resolve the error. Include any related code improvements that should be made concurrently for better quality or clarity.
 
    Please Include _All_ 4 items per Actionable Error.
-   Do NOT write codes in this stage.
+   Do NOT write codes unless the user ask to do in this stage.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -361,6 +361,7 @@ export default defineFlatConfig([
 		],
 
 		rules: {
+			'unicorn/no-array-method-this-argument': 'off',
 			'array-func/no-unnecessary-this-arg': 'off',
 			'@intlify/svelte/no-raw-text': 'off',
 			'functional/immutable-data': 'off',


### PR DESCRIPTION
dragDrop 인터랙션을 처리하는 로직을 개선하고, unmapper 헬퍼 함수를 추가했음. 
- discoverInteractions 함수에 verbose 매개변수를 추가하여 디버깅 정보를 출력하도록 수정했음.
- 각 인터랙션의 type을 명시적으로 설정하고, unmapper를 통해 원본 객체로 복원하는 기능을 추가했음.
- 스크롤 가능 여부를 확인하는 로직을 개선하고, 요소의 계산된 스타일을 기반으로 스크롤 가능성을 판단하도록 변경했음.
- fill, select, range, scroll 인터랙션 처리 시 index와 value를 포함하도록 mapper를 수정했음. 

이러한 변경은 코드의 가독성을 높이고, 인터랙션 처리의 일관성을 개선하기 위해 수행되었음.