### PR TITLE
feat: Node.js 버전 설정을 package.json으로 변경

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -44,13 +44,12 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.4.1
           run_install: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: 23.5.0
+          node-version-file: package.json
           cache: pnpm
 
       # 최적화된 설치 명령

--- a/.github/workflows/check_lint.yml
+++ b/.github/workflows/check_lint.yml
@@ -42,14 +42,13 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.4.1
           run_install: false
 
       # Node.js 환경 설정 (package.json의 engines.node 버전과 일치)
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 23.5.0
+          node-version-file: package.json
           cache: pnpm
 
       # 의존성 설치 최적화

--- a/.github/workflows/mutate_code.yml
+++ b/.github/workflows/mutate_code.yml
@@ -77,14 +77,13 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.4.1
           run_install: false
 
       # Node.js 환경 설정 (package.json의 engines.node 버전과 일치)
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 23.5.0
+          node-version-file: package.json
           cache: pnpm
 
       # 의존성 설치 최적화
@@ -196,14 +195,13 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.4.1
           run_install: false
 
       # Node.js 환경 설정 (package.json의 engines.node 버전과 일치)
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 23.5.0
+          node-version-file: package.json
           cache: pnpm
 
       # 의존성 설치 최적화
@@ -296,12 +294,11 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.4.1
           run_install: false
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 23.5.0
+          node-version-file: package.json
           cache: pnpm
 
       # package-json 패치 다운로드 및 적용


### PR DESCRIPTION
Node.js 환경 설정에서 node-version을 package.json의 node-version-file로 변경했음. 
pnpm의 version 설정을 제거했음. 
이로 인해 Node.js 버전 관리가 package.json에 통합되어 일관성을 높였음.