### PR TITLE
feat: Markdown 파일 포맷팅 패턴 확장

### DIFF
--- a/.github/workflows/mutate_code.yml
+++ b/.github/workflows/mutate_code.yml
@@ -209,7 +209,7 @@ jobs:
         run: pnpm install --prefer-offline
 
       - name: Format Markdown
-        run: pnpm run format-all-path '**/*.md'
+        run: pnpm run format-all-path '**/*.{md,mdx}'
 
       - name: Check for Markdown changes
         id: check_markdown_changes


### PR DESCRIPTION
Markdown 파일 포맷팅 시 `md` 파일뿐만 아니라 `mdx` 파일도 포함하도록 패턴을 수정했음.  
이로 인해 Markdown 및 MDX 파일 모두에 대해 일관