### PR TITLE
feat(eslint.config): allow default project for markdown files 추가

### DIFF
--- a/.cursor/docs/xstate-svelte.md
+++ b/.cursor/docs/xstate-svelte.md
@@ -1,6 +1,6 @@
 # @xstate/svelte
 
-The '@xstate/svelte' package contains utilities for using XState with Svelte.
+The @xstate/svelte package contains utilities for using XState with Svelte.
 
 ## API
 

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -4,8 +4,6 @@
 **/*.toml
 **/*.yaml
 **/*.yml
-**/*.md
-**/*.mdx
 **/*.jsonc
 **/*.json5
 **/*.sql

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -338,6 +338,11 @@ export default defineFlatConfig([
 				projectService: true,
 				requireConfigFile: false,
 				sourceType: 'module',
+				allowDefaultProject: [
+					'**/*.md/*.*',
+					'**/*.mdc/*.*',
+					'**/*.mdx/*.*',
+				],
 			},
 			sourceType: 'module',
 		},
@@ -364,6 +369,11 @@ export default defineFlatConfig([
 				projectService: true,
 				requireConfigFile: false,
 				sourceType: 'module',
+				allowDefaultProject: [
+					'**/*.md/*.*',
+					'**/*.mdc/*.*',
+					'**/*.mdx/*.*',
+				],
 				svelteConfig,
 				svelteFeatures: {
 					experimentalRunes: true,


### PR DESCRIPTION
eslint.config.js에서 allowDefaultProject 설정에 markdown 관련 파일 패턴 추가.  
stylelintignore에서 markdown 파일 패턴 제거.  
이 변경으로 markdown 파일에 대한 ESLint 적용 가능.