### PR TITLE
fix: auto_merge.yml에서 불필요한 코드 제거

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -64,7 +64,6 @@ jobs:
         with:
           github-token: ${{ secrets.TOKEN1 }}
           script: |
-            const core = require('@actions/core');
             try {
               await github.rest.issues.removeLabel({
                 issue_number: context.issue.number,


### PR DESCRIPTION
auto_merge.yml 파일에서 '@actions/core' 모듈의 불필요한 import 문을 제거했음. 코드 간결성을 높이고 유지보수를 용이하게 하기 위함.