### PR TITLE
feat: remove-mutation-finished-label 작업 수정

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -50,12 +50,12 @@ jobs:
           GH_TOKEN: ${{secrets.TOKEN1}}
 
   remove-mutation-finished-label:
-    needs: [automerge-dependabot]
+    needs: [automerge, automerge-dependabot]
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    if: contains(github.event.pull_request.labels.*.name, 'mutation-finished')
+    if: always() && contains(github.event.pull_request.labels.*.name, 'mutation-finished')
 
     steps:
       - name: Remove mutation-finished Label


### PR DESCRIPTION
remove-mutation-finished-label 작업의 needs를 automerge와 automerge-dependabot으로 변경함. 
if 조건을 항상(true)로 설정하여 mutation-finished 라벨이 있는 경우에만 작업이 실행되도록 수정했음.