### PR TITLE
feat(docs): xstate-test 문서에서 불필요한 공백 제거

### DIFF
--- a/.cursor/docs/xstate-test.md
+++ b/.cursor/docs/xstate-test.md
@@ -59,7 +59,7 @@ The @xstate/test package contains utilities for facilitating model-based testing
 
    ```js
    import { createMachine } from 'xstate'
-   
+
    const toggleMachine = createMachine({
    	id: 'toggle',
    	initial: 'inactive',
@@ -82,7 +82,7 @@ The @xstate/test package contains utilities for facilitating model-based testing
 
    ```js
    // ...
-   
+
    const toggleMachine = createMachine({
    	id: 'toggle',
    	initial: 'inactive',
@@ -116,9 +116,9 @@ The @xstate/test package contains utilities for facilitating model-based testing
    ```js
    import { createModel } from '@xstate/test'
    import { createMachine } from 'xstate'
-   
+
    const toggleMachine = createMachine(/* ... */)
-   
+
    const toggleModel = createModel(toggleMachine).withEvents({
    	TOGGLE: {
    		exec: async (page) => {
@@ -132,22 +132,22 @@ The @xstate/test package contains utilities for facilitating model-based testing
 
    ```js
    // ...
-   
+
    describe('toggle', () => {
    	const testPlans = toggleModel.getShortestPathPlans()
-   
+
    	for (const plan of testPlans) {
    		describe(plan.description, () => {
    			for (const path of plan.paths) {
    				it(path.description, async () => {
    					// do any setup, then...
-   
+
    					await path.test(page)
    				})
    			}
    		})
    	}
-   
+
    	it('should have full coverage', () => {
    		return toggleModel.testCoverage()
    	})

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -483,13 +483,8 @@ export default defineFlatConfig([
 	},
 
 	...markdown.configs.recommended,
-	{
-		files: ['**/*.md', '**/*.mdc'],
-		plugins: {
-			markdown,
-		},
-		language: "markdown/commonmark",
-	},
+	...markdown.configs.processor,
+
 	{
 		files: [
 			'**/*.md/*.*',


### PR DESCRIPTION
xstate-test 문서에서 코드 블록 사이의 불필요한 공백을 제거했음. 
eslint.config.js에서 markdown 설정을 간소화했음. 
이로 인해 문서의 가독성이 향상되고, 코드 스타일 일관성이 유지됨.