### PR TITLE
ci: auto_merge workflow에 30초 대기 추가

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -65,6 +65,7 @@ jobs:
           github-token: ${{ secrets.TOKEN1 }}
           script: |
             try {
+              await new Promise(resolve => setTimeout(resolve, 30000)); // 30초 대기
               await github.rest.issues.removeLabel({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,


### PR DESCRIPTION
GitHub Actions auto_merge 워크플로우에서 레이블 제거 전 30초 대기 시간을 추가함.  
이는 비동기 처리 시점 문제를 완화하고 안정성을 높이기 위함임.