### PR TITLE
ci: auto_merge workflow에 30초 대기 추가

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -65,6 +65,7 @@ jobs:
           github-token: ${{ secrets.TOKEN1 }}
           script: |
             try {
+              await new Promise(resolve => setTimeout(resolve, 30000)); // 30초 대기
               await github.rest.issues.removeLabel({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,

--- a/.github/workflows/check_lint.yml
+++ b/.github/workflows/check_lint.yml
@@ -56,7 +56,7 @@ jobs:
         run: pnpm install --prefer-offline
 
       - name: paraglide-compile
-        run: turbo run build --filter=@library/paraglide
+        run: pnpm exec turbo run build --filter=@library/paraglide
 
       # 린트 실행
       - name: Run Lint


### PR DESCRIPTION
GitHub Actions auto_merge 워크플로우 내에서 레이블 제거 전 30초 대기 로직 추가  
비동기 처리 안정성 및 race condition 완화 목적임