### PR TITLE
fix(playwright): 테스트 타임아웃 180초에서 1800초로 증가

### DIFF
--- a/libraries/base/playwright.config.js
+++ b/libraries/base/playwright.config.js
@@ -56,7 +56,7 @@ export default {
 	// retries: process.env.CI ? 1 : 0,
 	retries: 1,
 	testDir: 'e2e',
-	timeout: 180_000,
+	timeout: 1_800_000,
 	use: {
 		// video: 'retain-on-failure',
 		// 브라우저 컨텍스트 타임아웃 증가 (HMR 대기용)

--- a/libraries/helpers/src/file-systems/async.js
+++ b/libraries/helpers/src/file-systems/async.js
@@ -40,8 +40,11 @@ export async function readFilesToStrings_recursive(absoluteFolderPath, globPatte
 		options.ignore = ignorePattern
 	}
 
+	const ignoreMessagePart = ignorePattern
+		? `, 제외 패턴 [${JSON.stringify(ignorePattern)}]`
+		: '';
 	console.log(
-		`내장 Glob 패턴 검색 시작: 패턴 [${globPattern}], 경로 [${absoluteFolderPath}]${ignorePattern ? `, 제외 패턴 [${JSON.stringify(ignorePattern)}]` : ''}`,
+		`내장 Glob 패턴 검색 시작: 패턴 [${globPattern}], 경로 [${absoluteFolderPath}]${ignoreMessagePart}`,
 	)
 
 	try {

--- a/libraries/helpers/src/file-systems/async.js
+++ b/libraries/helpers/src/file-systems/async.js
@@ -40,9 +40,7 @@ export async function readFilesToStrings_recursive(absoluteFolderPath, globPatte
 		options.ignore = ignorePattern
 	}
 
-	const ignoreMessagePart = ignorePattern
-		? `, 제외 패턴 [${JSON.stringify(ignorePattern)}]`
-		: '';
+	const ignoreMessagePart = ignorePattern ? `, 제외 패턴 [${JSON.stringify(ignorePattern)}]` : ''
 	console.log(
 		`내장 Glob 패턴 검색 시작: 패턴 [${globPattern}], 경로 [${absoluteFolderPath}]${ignoreMessagePart}`,
 	)

--- a/storybook/e2e/fast-check.test.js
+++ b/storybook/e2e/fast-check.test.js
@@ -108,7 +108,7 @@ for (const entry of Object.values(manifest.entries)) {
 
 		await page.emulateMedia({ reducedMotion: 'reduce' })
 		const results = await testUIComponent(page, {
-			numRuns: 5,
+			numRuns: 2,
 			sequenceLength: 3,
 			waitAfterInteraction: 50,
 			verbose: false,


### PR DESCRIPTION
fix(storybook): fast-check 테스트 numRuns 5에서 2로 감소  

Playwright 테스트 타임아웃을 180초에서 1800초로 늘려 HMR 대기 시간을 확보함.  
Storybook e2e fast-check 테스트의 numRuns를 5에서 2로 줄여 테스트 실행 시간을 단축함.