### PR TITLE
test: fast-check 테스트 numRuns를 2에서 5로 증가시킴

### DIFF
--- a/storybook/e2e/fast-check.test.js
+++ b/storybook/e2e/fast-check.test.js
@@ -108,7 +108,7 @@ for (const entry of Object.values(manifest.entries)) {
 
 		await page.emulateMedia({ reducedMotion: 'reduce' })
 		const results = await testUIComponent(page, {
-			numRuns: 2,
+			numRuns: 5,
 			sequenceLength: 3,
 			waitAfterInteraction: 50,
 			verbose: false,


### PR DESCRIPTION
fast-check 테스트의 반복 횟수를 2회에서 5회로 늘려 테스트 신뢰도 향상 목적임