### PR TITLE
fix(storybook): click 및 doubleClick 타임아웃 늘리고 locator 사용으로 안정성 개선

### DIFF
--- a/storybook/e2e/universal-testers.js
+++ b/storybook/e2e/universal-testers.js
@@ -803,13 +803,14 @@ async function executeInteractionByType(page, interaction, result) {
 	try {
 		switch (interaction.type) {
 			case 'click': {
-				await page.click(interaction.selector, { timeout: 5000 }) // 타임아웃 추가
+				const locator = page.locator(interaction.selector);
+				await locator.click({ timeout: 7000 }); // 타임아웃 늘리고 locator 사용
 				result.message = '클릭'
 				break
 			}
 			case 'doubleClick': {
 				const locator = page.locator(interaction.selector)
-				await locator.dblclick({ timeout: 5000 })
+				await locator.dblclick({ timeout: 7000 }); // 타임아웃 늘림
 				result.message = '더블 클릭'
 				break
 			}

--- a/storybook/e2e/universal-testers.js
+++ b/storybook/e2e/universal-testers.js
@@ -803,14 +803,14 @@ async function executeInteractionByType(page, interaction, result) {
 	try {
 		switch (interaction.type) {
 			case 'click': {
-				const locator = page.locator(interaction.selector);
-				await locator.click({ timeout: 7000 }); // 타임아웃 늘리고 locator 사용
+				const locator = page.locator(interaction.selector)
+				await locator.click({ timeout: 7000 }) // 타임아웃 늘리고 locator 사용
 				result.message = '클릭'
 				break
 			}
 			case 'doubleClick': {
 				const locator = page.locator(interaction.selector)
-				await locator.dblclick({ timeout: 7000 }); // 타임아웃 늘림
+				await locator.dblclick({ timeout: 7000 }) // 타임아웃 늘림
 				result.message = '더블 클릭'
 				break
 			}


### PR DESCRIPTION
page.click 대신 page.locator를 사용해 클릭 동작 수행하도록 변경했음  
타임아웃을 5000ms에서 7000ms로 늘려 테스트 안정성 향상시켰음