### PR TITLE
fix(ci): link check workflow 및 mutation label 추가 방식 수정

### DIFF
--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -1,7 +1,7 @@
 name: Link Check
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - labeled
       - synchronize
@@ -25,7 +25,7 @@ jobs:
       - name: Run linkspector
         uses: umbrelladocs/action-linkspector@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           fail_level: any
           config_file: .linkspector.yml

--- a/.github/workflows/mutate_code.yml
+++ b/.github/workflows/mutate_code.yml
@@ -966,13 +966,11 @@ jobs:
 
       # 라벨 추가
       - name: PR에 라벨 추가 2 (mutation-finished)
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.TOKEN1 }}
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['mutation-finished']
-            })
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN1 }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "Adding label mutation-finished to PR #$PR_NUMBER in repo $REPO"
+          gh issue edit $PR_NUMBER --add-label "mutation-finished" --repo $REPO
+          echo "Label addition command executed."

--- a/storybook/e2e/fast-check.test.js
+++ b/storybook/e2e/fast-check.test.js
@@ -108,7 +108,7 @@ for (const entry of Object.values(manifest.entries)) {
 
 		await page.emulateMedia({ reducedMotion: 'reduce' })
 		const results = await testUIComponent(page, {
-			numRuns: 5,
+			numRuns: 10,
 			sequenceLength: 3,
 			waitAfterInteraction: 50,
 			verbose: false,


### PR DESCRIPTION
.github/workflows/link_check.yml에서 github_token 환경변수 이름을 GITHUB_TOKEN으로 수정하고, pull_request 이벤트로 변경함  
storybook 테스트 numRuns를 5에서 10으로 증가시켜 테스트 반복 횟수 확대  
.github/workflows/mutate_code.yml에서 mutation-finished 라벨 추가 방식을 actions/github-script에서 gh CLI 사용으로 변경하여 안정성 및 가독성 개선