### PR TITLE
test: fast-check 테스트 numRuns 값을 10에서 5로 감소시킴

### DIFF
--- a/storybook/e2e/fast-check.test.js
+++ b/storybook/e2e/fast-check.test.js
@@ -108,7 +108,7 @@ for (const entry of Object.values(manifest.entries)) {
 
 		await page.emulateMedia({ reducedMotion: 'reduce' })
 		const results = await testUIComponent(page, {
-			numRuns: 10,
+			numRuns: 5,
 			sequenceLength: 3,
 			waitAfterInteraction: 50,
 			verbose: false,


### PR DESCRIPTION
fast-check 테스트 실행 횟수를 줄여 테스트 시간 단축을 목적으로 변경함.  
테스트의 신뢰성 유지하면서 효율성 개선에 기여함.