### PR TITLE
ci: auto_merge workflow 조건문 단순화

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -13,10 +13,8 @@ jobs:
       contents: write
       pull-requests: write
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'dependabot') && (
-      (github.event.action == 'labeled' && github.event.label.name == 'mutation-finished') ||
-      (github.event.action == 'synchronize' && contains(github.event.head_commit.message, '[automated-mutation]'))
-      )
+      !contains(github.event.pull_request.labels.*.name, 'dependabot') &&
+      github.event.action == 'labeled' && github.event.label.name == 'mutation-finished'
 
     steps:
       - uses: reitermarkus/automerge@v2
@@ -31,10 +29,8 @@ jobs:
       contents: write
       pull-requests: write
     if: |
-      contains(github.event.pull_request.labels.*.name, 'dependabot') && (
-      (github.event.action == 'labeled' && github.event.label.name == 'mutation-finished') ||
-      (github.event.action == 'synchronize' && contains(github.event.head_commit.message, '[automated-mutation]'))
-      )
+      contains(github.event.pull_request.labels.*.name, 'dependabot') &&
+      github.event.action == 'labeled' && github.event.label.name == 'mutation-finished'
 
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
.github/workflows/auto_merge.yml 내 auto_merge 작업의 if 조건문에서 중복된 분기 제거 및 간결화함.  
dependabot 레이블과 mutation-finished 라벨이 동시에 존재하는 경우에만 동작하도록 조건을 명확히 하여 불필요한 복합 조건을 줄임.  
이로 인해 워크플로우 실행 조건이 명확해지고 유지보수가 용이해짐.