### PR TITLE
fix(workflows): auto_merge 대기 시간 단축 및 check_lint fetch-depth 수정

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -61,7 +61,7 @@ jobs:
           github-token: ${{ secrets.TOKEN1 }}
           script: |
             try {
-              await new Promise(resolve => setTimeout(resolve, 30000)); // 30초 대기
+              await new Promise(resolve => setTimeout(resolve, 1000));
               await github.rest.issues.removeLabel({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,

--- a/.github/workflows/check_lint.yml
+++ b/.github/workflows/check_lint.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 2
+          fetch-depth: 0
           token: ${{ secrets.TOKEN1 }}
 
       - name: Cache turbo build setup


### PR DESCRIPTION
auto_merge 워크플로우에서 대기 시간을 30초에서 1초로 단축함  
check_lint 워크플로우에서 fetch-depth를 2에서 0으로 변경하여 전체 커밋 기록을 가져오도록 수정함