### PR TITLE
ci: mutation-finished 라벨 자동 제거 워크플로우 추가 및 불필요 대기 제거

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -7,6 +7,38 @@ on:
       - synchronize
 
 jobs:
+  remove-mutation-finished-label:
+    needs: [automerge, automerge-dependabot]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: always() && contains(github.event.pull_request.labels.*.name, 'mutation-finished')
+
+    steps:
+      - name: Remove mutation-finished Label
+        if: always()
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.TOKEN1 }}
+          script: |
+            try {
+              await new Promise(resolve => setTimeout(resolve, 1000));
+              await github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'mutation-finished'
+              });
+              core.info('Label "mutation-finished" removed successfully.');
+            } catch (error) {
+              if (error.status === 404) {
+                core.info('Label "mutation-finished" not found or already removed.');
+              } else {
+                core.setFailed(`Error removing label: ${error.message}`);
+              }
+            }
+
   automerge:
     runs-on: ubuntu-latest
     permissions:
@@ -44,35 +76,3 @@ jobs:
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.TOKEN1}}
-
-  remove-mutation-finished-label:
-    needs: [automerge, automerge-dependabot]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    if: always() && contains(github.event.pull_request.labels.*.name, 'mutation-finished')
-
-    steps:
-      - name: Remove mutation-finished Label
-        if: always()
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.TOKEN1 }}
-          script: |
-            try {
-              await new Promise(resolve => setTimeout(resolve, 1000));
-              await github.rest.issues.removeLabel({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: 'mutation-finished'
-              });
-              core.info('Label "mutation-finished" removed successfully.');
-            } catch (error) {
-              if (error.status === 404) {
-                core.info('Label "mutation-finished" not found or already removed.');
-              } else {
-                core.setFailed(`Error removing label: ${error.message}`);
-              }
-            }

--- a/.github/workflows/mutate_code.yml
+++ b/.github/workflows/mutate_code.yml
@@ -70,7 +70,6 @@ jobs:
         with:
           github-token: ${{ secrets.TOKEN1 }}
           script: |
-            await new Promise(resolve => setTimeout(resolve, 30000)); // 30초 대기
             try {
               await github.rest.issues.removeLabel({
                 issue_number: context.issue.number,


### PR DESCRIPTION
.github/workflows/auto_merge.yml에 mutation-finished 라벨을 자동으로 제거하는 remove-mutation-finished-label job 추가함  
.github/workflows/mutate_code.yml에서 불필요한 30초 대기 코드 제거하여 실행 효율 개선함  
mutation-finished 라벨 제거 시 에러 처리 및 로그 출력 추가로 안정성 강화함