### PR TITLE
chore(turbo): outputs 설정에서 불필요 경로 제거

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -54,6 +54,11 @@ jobs:
           github-token: ${{ secrets.TOKEN1 }}
           script: |
             try {
+              await new Promise((resolve, reject) => {
+                setTimeout(() => {
+                  resolve();
+                }, 1000);
+              });
               await github.rest.issues.removeLabel({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,

--- a/.github/workflows/mutate_code.yml
+++ b/.github/workflows/mutate_code.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, labeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 env:
   HUSKY: 0
 

--- a/libraries/scripts/src/translation/paraglide/prompt.md
+++ b/libraries/scripts/src/translation/paraglide/prompt.md
@@ -220,9 +220,11 @@
 
 
 
-/\*\*\_Represents the structured output for the translation task.\_THE FINAL OUTPUT MUST BE ONLY THIS JSON OBJECT.*/interface TranslationOutput {/\_\** The translated messages, keyed by the original message number.*Keys MUST be the sequential integer strings from the input TARGET MESSAGES (e.g., "1", "2", "3", ...).* Values MUST be strings or valid Paraglide variant objects (matching/pluralization).*Example (proactive pluralization applied): "4": { "declarations": ["input itemCount", ...], "match": { "countPlural=one": "1 item", "countPlural=other": "{itemCount} items" } }\*/translatedMessages: { [messageNumber: string]: string | object };    		/**    			* Newly identified terms and their translations for future consistency.    			* @additionalProperties {string}    			* @example { "SourceTerm1": "TranslatedTerm1", "SourceTerm2": "TranslatedTerm2" }
-    			*/
-    		newDictionary: { [sourceTerm: string]: string };
+
+
+
+
+/\*\*\_Represents the structured output for the translation task.\_THE FINAL OUTPUT MUST BE ONLY THIS JSON OBJECT.*/interface TranslationOutput {/\_\** The translated messages, keyed by the original message number.*Keys MUST be the sequential integer strings from the input TARGET MESSAGES (e.g., "1", "2", "3", ...).* Values MUST be strings or valid Paraglide variant objects (matching/pluralization).*Example (proactive pluralization applied): "4": { "declarations": ["input itemCount", ...], "match": { "countPlural=one": "1 item", "countPlural=other": "{itemCount} items" } }\*/translatedMessages: { [messageNumber: string]: string | object };    		/**    			* Newly identified terms and their translations for future consistency.    			* @additionalProperties {string}    			* @example { "SourceTerm1": "TranslatedTerm1", "SourceTerm2": "TranslatedTerm2" }    			*/    		newDictionary: { [sourceTerm: string]: string };
     	}
     	```
 

--- a/libraries/scripts/src/translation/paraglide/prompt.md
+++ b/libraries/scripts/src/translation/paraglide/prompt.md
@@ -5,234 +5,176 @@
 <Instructions>
 		**Overall Task:** Translate the provided `TARGET MESSAGES` into the specified `TARGET LANGUAGE`, ensuring consistency with `OLDER MESSAGES` and the `DICTIONARY`. The `TARGET MESSAGES` object uses sequential integer strings starting from "1" as keys (e.g., "1", "2", "3", ...). You MUST perform the analysis and translation steps internally as described below. The **FINAL OUTPUT MUST BE ONLY** the JSON object containing `translatedMessages` and `newDictionary`, conforming EXACTLY to the `Output_Schema`. The keys in the `translatedMessages` object MUST correspond to the original sequential keys from `TARGET MESSAGES`.
 
-		**Internal Process (You MUST explicitly show your thinking process step-by-step for sections 1 and 2 below. This thinking process is NOT part of the final JSON output but is crucial for transparency and verification):**
+    	**Internal Process (You MUST explicitly show your thinking process step-by-step for sections 1 and 2 below. This thinking process is NOT part of the final JSON output but is crucial for transparency and verification):**
 
-		1.  **Understand Task and Inputs:**
-				*   **(Thinking Step 1 Start) Now I will articulate my understanding of the task and inputs.**
-				*   Confirm your understanding of the core task, inputs (`TARGET LANGUAGE`, `OLDER MESSAGES`, `DICTIONARY`, `TARGET MESSAGES` with keys "1", "2", ...), and constraints (Paraglide Rules including proactive pluralization, Style Guide, Final Output Format with sequential keys in `translatedMessages`).
-				*   **(Thinking Step 1 End)**
+    	1.  **Understand Task and Inputs:**
+    			*   **(Thinking Step 1 Start) Now I will articulate my understanding of the task and inputs.**
+    			*   Confirm your understanding of the core task, inputs (`TARGET LANGUAGE`, `OLDER MESSAGES`, `DICTIONARY`, `TARGET MESSAGES` with keys "1", "2", ...), and constraints (Paraglide Rules including proactive pluralization, Style Guide, Final Output Format with sequential keys in `translatedMessages`).
+    			*   **(Thinking Step 1 End)**
 
-		2.  **Analyze Subtle Parts (CRITICAL Internal Thinking Step - `planForSubtleParts`):**
-				*   **(Thinking Step 2 Start) Now I will analyze subtle parts and formulate a plan.**
-				*   **You MUST meticulously perform this internal analysis step.**
-				*   Carefully review ALL `TARGET MESSAGES` corresponding to keys "1", "2", etc.
-				*   Identify any parts (words, phrases, parameters, message structures) that are particularly subtle, tricky, or require careful handling for the `TARGET LANGUAGE` and style guide. This **MUST include identifying potential needs for proactive pluralization based on parameters** when translating to English or similar languages.
-				*   For EACH identified part, you MUST internally formulate a detailed plan covering:
-						*   `part`: The specific part identified.
-						*   `why`: The reason it's challenging or needs special attention (e.g., nuance, Paraglide rule application, pluralization).
-						*   `plan`: Your specific strategy for translating it according to all rules and guides.
-				*   **As part of your internal thinking process, before proceeding to Step 3 (Translate Messages), you MUST explicitly list each identified subtle part and its corresponding `part`, `why`, and `plan` that you have formulated. This explicit listing is for a clear articulation of your internal reasoning process and will NOT be part of the final JSON output.**
-				*   **Consult the `Paraglide Rules`, `Translation_Style_Guide`, `Input` definitions, and `Examples` extensively when formulating this internal plan.**
-				*   This detailed internal plan is ESSENTIAL for guiding your translation in Step 3. **It WILL NOT and MUST NOT be part of the final JSON output**, but its thorough execution is mandatory for high-quality translation.
-				*   **(Thinking Step 2 End)**
+    	2.  **Analyze Subtle Parts (CRITICAL Internal Thinking Step - `planForSubtleParts`):**
+    			*   **(Thinking Step 2 Start) Now I will analyze subtle parts and formulate a plan.**
+    			*   **You MUST meticulously perform this internal analysis step.**
+    			*   Carefully review ALL `TARGET MESSAGES` corresponding to keys "1", "2", etc.
+    			*   Identify any parts (words, phrases, parameters, message structures) that are particularly subtle, tricky, or require careful handling for the `TARGET LANGUAGE` and style guide. This **MUST include identifying potential needs for proactive pluralization based on parameters** when translating to English or similar languages.
+    			*   For EACH identified part, you MUST internally formulate a detailed plan covering:
+    					*   `part`: The specific part identified.
+    					*   `why`: The reason it's challenging or needs special attention (e.g., nuance, Paraglide rule application, pluralization).
+    					*   `plan`: Your specific strategy for translating it according to all rules and guides.
+    			*   **As part of your internal thinking process, before proceeding to Step 3 (Translate Messages), you MUST explicitly list each identified subtle part and its corresponding `part`, `why`, and `plan` that you have formulated. This explicit listing is for a clear articulation of your internal reasoning process and will NOT be part of the final JSON output.**
+    			*   **Consult the `Paraglide Rules`, `Translation_Style_Guide`, `Input` definitions, and `Examples` extensively when formulating this internal plan.**
+    			*   This detailed internal plan is ESSENTIAL for guiding your translation in Step 3. **It WILL NOT and MUST NOT be part of the final JSON output**, but its thorough execution is mandatory for high-quality translation.
+    			*   **(Thinking Step 2 End)**
 
-		3.  **Translate Messages (`translatedMessages`):**
-				*   Execute the internal translation plan meticulously formulated in Step 2.
-				*   Translate each message for keys "1", "2", ... **using the provided `ko`, `en`, and `explanation` fields for full context and meaning.**
-				*   **Actively consult `OLDER MESSAGES` and `DICTIONARY` for consistency.**
-				*   **CRITICAL: Adhere STRICTLY to the Paraglide Rules (provided below).**
-						*   Handle parameters (`{}`) correctly.
-						*   Handle variants (Matching, Pluralization) correctly.
-						*   **PROACTIVE PLURALIZATION (Especially for English Target):** When translating to English (or other languages requiring grammatical number agreement), analyze parameters (`{paramName}`). If a parameter likely represents a count or countable noun (judging by its name like `{count}`, `{numItems}`, or context from the `explanation`), even if the source (e.g., Korean) doesn't show plural variation, **YOU MUST proactively apply the Paraglide pluralization structure.**
-								*   This typically involves adding:
-										*   `"declarations": ["input paramName", "local countPlural = paramName: plural"]`
-										*   `"selectors": ["countPlural"]`
-										*   `"match": { "countPlural=one": "...", "countPlural=other": "..." }` using `paramName` appropriately in the translated strings.
-								*   Use the `explanation` and common sense to determine if a parameter requires this proactive pluralization.
-						*   Ensure correct application of `Intl.PluralRules` for the **specified `TARGET LANGUAGE`**'s plural categories.
-				*   **CRITICAL: Adhere STRICTLY to the Translation Style Guide (provided below).**
-				*   The results of this step will form the `translatedMessages` object in the final JSON, using the original sequential keys ("1", "2", ...).
+    	3.  **Translate Messages (`translatedMessages`):**
+    			*   Execute the internal translation plan meticulously formulated in Step 2.
+    			*   Translate each message for keys "1", "2", ... **using the provided `ko`, `en`, and `explanation` fields for full context and meaning.**
+    			*   **Actively consult `OLDER MESSAGES` and `DICTIONARY` for consistency.**
+    			*   **CRITICAL: Adhere STRICTLY to the Paraglide Rules (provided below).**
+    					*   Handle parameters (`{}`) correctly.
+    					*   Handle variants (Matching, Pluralization) correctly.
+    					*   **PROACTIVE PLURALIZATION (Especially for English Target):** When translating to English (or other languages requiring grammatical number agreement), analyze parameters (`{paramName}`). If a parameter likely represents a count or countable noun (judging by its name like `{count}`, `{numItems}`, or context from the `explanation`), even if the source (e.g., Korean) doesn't show plural variation, **YOU MUST proactively apply the Paraglide pluralization structure.**
+    							*   This typically involves adding:
+    									*   `"declarations": ["input paramName", "local countPlural = paramName: plural"]`
+    									*   `"selectors": ["countPlural"]`
+    									*   `"match": { "countPlural=one": "...", "countPlural=other": "..." }` using `paramName` appropriately in the translated strings.
+    							*   Use the `explanation` and common sense to determine if a parameter requires this proactive pluralization.
+    					*   Ensure correct application of `Intl.PluralRules` for the **specified `TARGET LANGUAGE`**'s plural categories.
+    			*   **CRITICAL: Adhere STRICTLY to the Translation Style Guide (provided below).**
+    			*   The results of this step will form the `translatedMessages` object in the final JSON, using the original sequential keys ("1", "2", ...).
 
-		4.  **Generate New Dictionary (`newDictionary`):**
-				*   Review the translations produced in Step 3.
-				*   Identify new or significant translated terms.
-				*   Internally create the `newDictionary` object (`{ "source term": "translated term" }`). This will be the `newDictionary` part of the final JSON.
-				*   **CRITICAL: Only add terms that are essential for maintaining translation consistency across future messages. This can include menu names that are referenced in multiple UI texts and require consistent naming. If no such terms are identified, return an empty object (`{}`).**
+    	4.  **Generate New Dictionary (`newDictionary`):**
+    			*   Review the translations produced in Step 3.
+    			*   Identify new or significant translated terms.
+    			*   Internally create the `newDictionary` object (`{ "source term": "translated term" }`). This will be the `newDictionary` part of the final JSON.
+    			*   **CRITICAL: Only add terms that are essential for maintaining translation consistency across future messages. This can include menu names that are referenced in multiple UI texts and require consistent naming. If no such terms are identified, return an empty object (`{}`).**
 
-		5.  **Format and Output Final JSON:**
-				*   Combine `translatedMessages` (from Step 3) and `newDictionary` (from Step 4) into a single JSON object.
-				*   Ensure this JSON object conforms EXACTLY to the `Output_Schema` (which no longer includes `planForSubtleParts`).
-				*   Ensure the keys in the `translatedMessages` object are the sequential integer strings "1", "2", "3", ... corresponding to the input.
-				*   **OUTPUT ONLY THIS FINAL JSON OBJECT.** NO other text, explanation, reasoning, or introductory phrases should precede or follow the JSON output.
+    	5.  **Format and Output Final JSON:**
+    			*   Combine `translatedMessages` (from Step 3) and `newDictionary` (from Step 4) into a single JSON object.
+    			*   Ensure this JSON object conforms EXACTLY to the `Output_Schema` (which no longer includes `planForSubtleParts`).
+    			*   Ensure the keys in the `translatedMessages` object are the sequential integer strings "1", "2", "3", ... corresponding to the input.
+    			*   **OUTPUT ONLY THIS FINAL JSON OBJECT.** NO other text, explanation, reasoning, or introductory phrases should precede or follow the JSON output.
 
-		**Paraglide Rules (MUST FOLLOW):**
-		```text
-		- The translations you produce MUST follow the inlang message format for the Paraglide Web App translation library.
-		- If a word is enclosed in `{` and `}`, it signifies a parameter receiving a value from outside. This part MUST NOT be translated and MUST be left as is, so it can receive an argument with a matching name externally.
-		- Regarding Variants:
-			# Variants
+    	**Paraglide Rules (MUST FOLLOW):**
+    	```text
+    	- The translations you produce MUST follow the inlang message format for the Paraglide Web App translation library.
+    	- If a word is enclosed in `{` and `}`, it signifies a parameter receiving a value from outside. This part MUST NOT be translated and MUST be left as is, so it can receive an argument with a matching name externally.
+    	- Regarding Variants:
+    		# Variants
 
-			Variants enable pluralization, gendering, A/B testing, and more. They are a powerful feature of inlang that allows you to create different versions of a message based on conditions.
+    		Variants enable pluralization, gendering, A/B testing, and more. They are a powerful feature of inlang that allows you to create different versions of a message based on conditions.
 
-			## Matching
+    		## Matching
 
-			The message below will match the following conditions:
+    		The message below will match the following conditions:
 
-			| Platform | User Gender | Message |
-			| --- | --- | --- |
-			| android | male | {username} has to download the app on his phone from the Google Play Store. |
-			| ios | female | {username} has to download the app on her iPhone from the App Store. |
-			| \* | \* | The person has to download the app. |
+    		| Platform | User Gender | Message |
+    		| --- | --- | --- |
+    		| android | male | {username} has to download the app on his phone from the Google Play Store. |
+    		| ios | female | {username} has to download the app on her iPhone from the App Store. |
+    		| \* | \* | The person has to download the app. |
 
-			The example below uses the inlang message format plugin for illustrative purposes. The syntax may differ depending on the plugin you are using.
+    		The example below uses the inlang message format plugin for illustrative purposes. The syntax may differ depending on the plugin you are using.
 
-			```json
-					{
-						"jojo_mountain_day": [{
-							"match": {
-								"platform=android, userGender=male": "{username} has to download the app on his phone from the Google Play Store.",
-								"platform=ios, userGender=female": "{username} has to download the app on her iPhone from the App Store.",
-								"platform=*, userGender=*": "The person has to download the app."
-							}
-						}]
-					}
-			```
+    		```json
+    				{
+    					"jojo_mountain_day": [{
+    						"match": {
+    							"platform=android, userGender=male": "{username} has to download the app on his phone from the Google Play Store.",
+    							"platform=ios, userGender=female": "{username} has to download the app on her iPhone from the App Store.",
+    							"platform=*, userGender=*": "The person has to download the app."
+    						}
+    					}]
+    				}
+    		```
 
-			## Pluralization
+    		## Pluralization
 
-			You can define a variable in your message and then use it in the selector. Paraglide uses `Intl.PluralRules` under the hood to determine the plural form.
+    		You can define a variable in your message and then use it in the selector. Paraglide uses `Intl.PluralRules` under the hood to determine the plural form.
 
-			| Inputs | Condition | Message |
-			| --- | --- | --- |
-			| count=1 | countPlural=one | There is one cat. |
-			| count>1 | countPlural=other | There are many cats. |
+    		| Inputs | Condition | Message |
+    		| --- | --- | --- |
+    		| count=1 | countPlural=one | There is one cat. |
+    		| count>1 | countPlural=other | There are many cats. |
 
-			Read the `local countPlural = count: plural` syntax as "create a local variable `countPlural` that equals `plural(count)`".
+    		Read the `local countPlural = count: plural` syntax as "create a local variable `countPlural` that equals `plural(count)`".
 
-			```json
-					{
-					"some_happy_cat": [{
-							"declarations": ["input count", "local countPlural = count: plural"],
-							"selectors": ["countPlural"],
-							"match": {
-								"countPlural=one": "There is one cat.",
-								"countPlural=other": "There are many cats.",
-							},
-						}]
-					}
-			```
+    		```json
+    				{
+    				"some_happy_cat": [{
+    						"declarations": ["input count", "local countPlural = count: plural"],
+    						"selectors": ["countPlural"],
+    						"match": {
+    							"countPlural=one": "There is one cat.",
+    							"countPlural=other": "There are many cats.",
+    						},
+    					}]
+    				}
+    		```
 
-			### 1. Matching (Explanation)
+    		### 1. Matching (Explanation)
 
-			Use this when you want to display different messages based on conditions. Define the condition and the corresponding message within the `match` object.
+    		Use this when you want to display different messages based on conditions. Define the condition and the corresponding message within the `match` object.
 
-			**Example:**
+    		**Example:**
 
-			The following JSON format shows different download instruction messages based on the user's platform and gender.
+    		The following JSON format shows different download instruction messages based on the user's platform and gender.
 
-			```json
-			// Example: Branching messages based on platform and gender
-			{
-				"jojo_mountain_day": [{
-					"match": {
-						"platform=android, userGender=male": "{username} has to download the app on his phone from the Google Play Store.",
-						"platform=ios, userGender=female": "{username} has to download the app on her iPhone from the App Store.",
-						"platform=*, userGender=*": "The person has to download the app."
-					}
-				}]
-			}
-			```
+    		```json
+    		// Example: Branching messages based on platform and gender
+    		{
+    			"jojo_mountain_day": [{
+    				"match": {
+    					"platform=android, userGender=male": "{username} has to download the app on his phone from the Google Play Store.",
+    					"platform=ios, userGender=female": "{username} has to download the app on her iPhone from the App Store.",
+    					"platform=*, userGender=*": "The person has to download the app."
+    				}
+    			}]
+    		}
+    		```
 
-			- Keys within the `match` object define conditions in the format `variableName=value`. Multiple conditions can be combined using a comma (`,`).
-			- `platform=android, userGender=male` specifies the message for when the platform is 'android' and the user gender is 'male'.
-			- An asterisk (`*`) acts as a wildcard, used to set a default message for all cases not covered by other specific conditions.
+    		- Keys within the `match` object define conditions in the format `variableName=value`. Multiple conditions can be combined using a comma (`,`).
+    		- `platform=android, userGender=male` specifies the message for when the platform is 'android' and the user gender is 'male'.
+    		- An asterisk (`*`) acts as a wildcard, used to set a default message for all cases not covered by other specific conditions.
 
-			### 2. Pluralization (Explanation)
+    		### 2. Pluralization (Explanation)
 
-			Use this to display different messages based on quantity. Paraglide internally uses `Intl.PluralRules` to handle pluralization rules.
+    		Use this to display different messages based on quantity. Paraglide internally uses `Intl.PluralRules` to handle pluralization rules.
 
-			**Example:**
+    		**Example:**
 
-			Shows different messages based on the number of cats (`count`).
+    		Shows different messages based on the number of cats (`count`).
 
-			```json
-			// Example: Branching messages based on the number of cats
-			{
-			"some_happy_cat": [{
-					// Declare input variable 'count' and local variable 'countPlural'
-					"declarations": ["input count", "local countPlural = count: plural"],
-					// Use the 'countPlural' variable as the selection criterion
-					"selectors": ["countPlural"],
-					"match": {
-						// When count is 1 (plural rule: 'one')
-						"countPlural=one": "There is one cat.",
-						// When count is not 1 (plural rule: 'other')
-						"countPlural=other": "There are many cats."
-					},
-				}]
-			}
-			```
+    		```json
+    		// Example: Branching messages based on the number of cats
+    		{
+    		"some_happy_cat": [{
+    				// Declare input variable 'count' and local variable 'countPlural'
+    				"declarations": ["input count", "local countPlural = count: plural"],
+    				// Use the 'countPlural' variable as the selection criterion
+    				"selectors": ["countPlural"],
+    				"match": {
+    					// When count is 1 (plural rule: 'one')
+    					"countPlural=one": "There is one cat.",
+    					// When count is not 1 (plural rule: 'other')
+    					"countPlural=other": "There are many cats."
+    				},
+    			}]
+    		}
+    		```
 
-			- `declarations`: Declares variables to be used within the message.
-					- `input count`: Declares an input variable named `count`. This variable receives its value from outside.
-					- `local countPlural = count: plural`: Applies the `plural` function (internally using `Intl.PluralRules`) to the `count` variable and stores the result in a local variable named `countPlural`. This variable will hold a value corresponding to the language's plural rule ('one', 'other', 'few', 'many', etc.).
-			- `selectors`: Specifies which variable(s) to use as the basis for branching in the `match` object. Here, `countPlural` is used.
-			- `match`: Specifies different messages based on the value of the `countPlural` variable. For English, this is typically distinguished as 'one' and 'other'.
+    		- `declarations`: Declares variables to be used within the message.
+    				- `input count`: Declares an input variable named `count`. This variable receives its value from outside.
+    				- `local countPlural = count: plural`: Applies the `plural` function (internally using `Intl.PluralRules`) to the `count` variable and stores the result in a local variable named `countPlural`. This variable will hold a value corresponding to the language's plural rule ('one', 'other', 'few', 'many', etc.).
+    		- `selectors`: Specifies which variable(s) to use as the basis for branching in the `match` object. Here, `countPlural` is used.
+    		- `match`: Specifies different messages based on the value of the `countPlural` variable. For English, this is typically distinguished as 'one' and 'other'.
 
-								**Important Note on Proactive Pluralization:** When translating *into* languages like English from languages that may not explicitly mark plurals in the source text (e.g., Korean), you MUST proactively analyze parameters (`{paramName}`). If context (parameter name, explanation) suggests `paramName` represents a countable quantity, apply the pluralization structure (`declarations`, `selectors`, `match`) using `paramName` as the input, even if the source text doesn't vary.
-		```
+    							**Important Note on Proactive Pluralization:** When translating *into* languages like English from languages that may not explicitly mark plurals in the source text (e.g., Korean), you MUST proactively analyze parameters (`{paramName}`). If context (parameter name, explanation) suggests `paramName` represents a countable quantity, apply the pluralization structure (`declarations`, `selectors`, `match`) using `paramName` as the input, even if the source text doesn't vary.
+    	```
+
 </Instructions>
 
-<Translation_Style_Guide>
-		- Keep in mind that the translation target is UI text. The translation must properly convey the intended function of the message in the UI!!!
-		- The most important thing is to convey the meaning of the TARGET MESSAGES well without damaging it!
-				- DON'T OMIT **ANYTHING** FROM THE ORIGINAL CONTENT!
-				- Faithfully preserve every point of the original source text (Korean/English) in the translation and its unique metaphors. Do not alter or omit any point of the original content.
-				- If direct translation struggles to capture the full meaning and nuance of the original sentence in the target language without loss, you MAY elaborate or add necessary context in the translated sentence to ensure the original intent and subtlety are fully conveyed. Prioritize faithful representation over strict literalism when such additions are crucial for preserving meaning.
-				- YOU MUST NOT NORMALIZE WEIRD, BIZARRE, HARSH, CONTROVERSIAL, AGGRESSIVE, OR EXTREME WORDS, SENTENCES, PARAGRAPHS, METAPHORS, ANALOGIES, AND EXAMPLES!
-				- DON'T ADD METAPHORS THAT WEREN'T IN THE ORIGINAL TEXT. DON'T TRY TO DO OR ADD SOMETHING, JUST DO A GOOD JOB OF REPRESENTING AND GLUING THE TEXT THAT WAS ORIGINALLY GIVEN TO YOU.
-		- DON'T SOUND LIKE A MARKETER! DON'T WRITE TO SOUND LIKE MARKETING!
-		- USE ONLY THE EASIEST SENTENCES YOU CAN!
-				- NEVER USE UNNECESSARILY DIFFICULT WORDS. DON'T USE UNNECESSARILY COMPLEX EXPRESSIONS. IF SOMETHING CAN BE EXPRESSED WITH EASIER WORDS AND SIMPLER EXPRESSIONS, ALWAYS USE EASIER WORDS AND SIMPLER EXPRESSIONS. ALWAYS, IN EVERY PART OF YOUR WRITING.
-				- NEVER, EVER EMBELLISH YOUR WORDS, KEEP IT SIMPLE AND CLEAN. NEVER ADD ANY NEW METAPHORS. NEVER USE UNNECESSARILY DIFFICULT WORDS. DON'T USE UNNECESSARILY COMPLEX EXPRESSIONS. IF SOMETHING CAN BE EXPRESSED WITH EASIER WORDS AND SIMPLER EXPRESSIONS, ALWAYS USE EASIER WORDS AND SIMPLER EXPRESSIONS. ALWAYS, IN EVERY PART OF YOUR WRITING.
-		- OMIT your unnecessary padding out, superfluity, or fluff. Especially in the START and the END of your writing. Begin your writing with THE CORE content.
-		- Write in the style of "Paul Graham": Remember, Paul Graham advocates for writing that is as natural and straightforward as speaking. Avoid overly formal or complex language. Use simple, direct phrases and everyday vocabulary.
-		- Vary sentence length and structure to maintain a dynamic, engaging rhythm
-		- Use short paragraphs (2-4 sentences) to maintain a fast, engaging pace.
-		- **Honest and Direct:** Address topics head-on, without shying away from potentially uncomfortable truths. The writing should reflect a willingness to dive into the heart of the matter
-		- **Conversational Intelligence:** Write like you're explaining a concept to a smart friend. It's informative but not dry; engaging but not flippant. Avoid jargon unless it adds real value, and always explain it.
-		- Break down complex concepts into easily understandable segments.
-		- Repeat yourself (within reason)
-				- Even if you think you've made your point very clearly, it's worth restating it at the beginning and end of what you're writing to make sure the reader gets it.
-				- Example: We only have two boxes left. To solve this, we should order more.
-				- Revision: We only have two boxes left. To solve this shortage, we should order more.
-				- Example: Click next and enter your credentials when prompted. That will take you to the home screen.
-				- Revision: Click next and enter your credentials when prompted. Successfully authenticating will take you to the home screen.
-				- This duplication can feel repetitive when you're writing it, but it won't feel repetitive to your reader—it'll make your writing clearer and easier to follow.
-				- In summary: when editing, look for ways that you can restate your point, clarify, or provide closure for the reader.
-		- Clauses equivalent to "of" and "for" (Apply the principle to the TARGET LANGUAGE):
-				- Instead of using constructions with "of" or "for" (or their equivalents), rewrite the sentence to put more information before the noun. This ordering makes the sentence more efficient.
-				- Example: The manager of the team responsible for marketing
-				- Revision: The marketing team's manager
-				- In the rearranged version above, the reader can more quickly grasp what you mean, instead of having to revise her understanding after each clause.
-		- Split it up
-				- Break up long sentences into multiple shorter sentences.
-				- Also, break up sentences by adding commas where appropriate. For example, I've noticed a trend towards people dropping commas after subordinate clauses. I always add them back when I edit:
-				- Example: If you're looking for me I'll be in my office.
-				- Revision: If you're looking for me, I'll be in my office.
-				- Example: Due to the fog our flight was delayed.
-				- Revision: Due to the fog, our flight was delayed.
-		- Eliminate passive voice
-				- You've heard this advice before. But you should understand why you shouldn't use passive voice in your writing. It's not just "bad style."
-				- Passive voice obscures who or what is performing the action. Rewriting a passive construction to be active almost always makes what you're saying clearer and makes the sentence easier to read, because your reader can attribute the action to the right person or thing.
-				- Example: The fire alarm was pulled and the building was evacuated.
-				- Revision: The fire marshal pulled the alarm and the employees evacuated the building.
-				- Example: Millions of dollars were embezzled from the company.
-				- Revision: Two executives embezzled millions of dollars from the company.
-		- Be aware of your tone
-				- Know what kind of tone you're going for, and be consistent. You can be colloquial or formal, but not both.
-		- Avoid jargon and cliches
-				- In the business world, jargon means things like "deep dive" and "low-hanging fruit". Elsewhere, we love to use cliches. Especially baseball metaphors, for some reason: "step up to the plate", "hit it out of the park", "take a swing at it".
-				- It will always be better and clearer when you say exactly what you mean. Using jargon is lazy, and it assumes that the reader is part of the in-group that uses that jargon (see also: Don't assume knowledge, above). It can be difficult for non-native English speakers (or non-Americans, when it comes to baseball) to follow your writing when you use jargon and cliches.
-				- Example: tl;dr, if you can hack something together by EOD, that would be great.
-				- Revision: Can you deliver a prototype by the end of today?
-				- The original sentence has incomprehensible acronyms and tech slang, and doesn't even sound like a request. The second one is straightforward, and asks for what the writer needs and by when.
-		- Preserves terms developers actually use (e.g., "프로퍼티" over "속성"). Retain **ALL technical terms** (e.g., "singleton" → "싱글톤 (Singleton)", not "단일체" / "middleware" → "미들웨어 (Middleware)"), abbreviations (e.g., API, HTTP), code blocks, and symbols (e.g., `>`, `*`, `#`). When translating technical terms, include the original English term in parentheses after the translated term.
-		- Maintains code/format integrity for technical correctness. **Only translate** comments/strings within code.
-		- **REGIONAL LANGUAGE VARIATIONS**:
-				- If the `TARGET LANGUAGE` includes a specific `Region` (e.g., 'en-US', 'es-MX', 'fr-CA'), the translation MUST be tailored to the linguistic nuances and conventions of that specific region. Pay close attention to regional vocabulary, spelling, grammar, and cultural references to ensure the translation is natural and appropriate for the intended audience in that region.
-		- **NEUTRAL LANGUAGE FOR UNSPECIFIED REGION**:
-				- If the `TARGET LANGUAGE` does not specify a `Region` (e.g., 'en' instead of 'en-US'), the translation should aim for the most globally understood and neutral form of the language. Avoid region-specific idioms, slang, or cultural references unless they are widely understood internationally or are essential to the meaning of the source text and cannot be conveyed otherwise.
+<Translation_Style_Guide> - Keep in mind that the translation target is UI text. The translation must properly convey the intended function of the message in the UI!!! - The most important thing is to convey the meaning of the TARGET MESSAGES well without damaging it! - DON'T OMIT **ANYTHING** FROM THE ORIGINAL CONTENT! - Faithfully preserve every point of the original source text (Korean/English) in the translation and its unique metaphors. Do not alter or omit any point of the original content. - If direct translation struggles to capture the full meaning and nuance of the original sentence in the target language without loss, you MAY elaborate or add necessary context in the translated sentence to ensure the original intent and subtlety are fully conveyed. Prioritize faithful representation over strict literalism when such additions are crucial for preserving meaning. - YOU MUST NOT NORMALIZE WEIRD, BIZARRE, HARSH, CONTROVERSIAL, AGGRESSIVE, OR EXTREME WORDS, SENTENCES, PARAGRAPHS, METAPHORS, ANALOGIES, AND EXAMPLES! - DON'T ADD METAPHORS THAT WEREN'T IN THE ORIGINAL TEXT. DON'T TRY TO DO OR ADD SOMETHING, JUST DO A GOOD JOB OF REPRESENTING AND GLUING THE TEXT THAT WAS ORIGINALLY GIVEN TO YOU. - DON'T SOUND LIKE A MARKETER! DON'T WRITE TO SOUND LIKE MARKETING! - USE ONLY THE EASIEST SENTENCES YOU CAN! - NEVER USE UNNECESSARILY DIFFICULT WORDS. DON'T USE UNNECESSARILY COMPLEX EXPRESSIONS. IF SOMETHING CAN BE EXPRESSED WITH EASIER WORDS AND SIMPLER EXPRESSIONS, ALWAYS USE EASIER WORDS AND SIMPLER EXPRESSIONS. ALWAYS, IN EVERY PART OF YOUR WRITING. - NEVER, EVER EMBELLISH YOUR WORDS, KEEP IT SIMPLE AND CLEAN. NEVER ADD ANY NEW METAPHORS. NEVER USE UNNECESSARILY DIFFICULT WORDS. DON'T USE UNNECESSARILY COMPLEX EXPRESSIONS. IF SOMETHING CAN BE EXPRESSED WITH EASIER WORDS AND SIMPLER EXPRESSIONS, ALWAYS USE EASIER WORDS AND SIMPLER EXPRESSIONS. ALWAYS, IN EVERY PART OF YOUR WRITING. - OMIT your unnecessary padding out, superfluity, or fluff. Especially in the START and the END of your writing. Begin your writing with THE CORE content. - Write in the style of "Paul Graham": Remember, Paul Graham advocates for writing that is as natural and straightforward as speaking. Avoid overly formal or complex language. Use simple, direct phrases and everyday vocabulary. - Vary sentence length and structure to maintain a dynamic, engaging rhythm - Use short paragraphs (2-4 sentences) to maintain a fast, engaging pace. - **Honest and Direct:** Address topics head-on, without shying away from potentially uncomfortable truths. The writing should reflect a willingness to dive into the heart of the matter - **Conversational Intelligence:** Write like you're explaining a concept to a smart friend. It's informative but not dry; engaging but not flippant. Avoid jargon unless it adds real value, and always explain it. - Break down complex concepts into easily understandable segments. - Repeat yourself (within reason) - Even if you think you've made your point very clearly, it's worth restating it at the beginning and end of what you're writing to make sure the reader gets it. - Example: We only have two boxes left. To solve this, we should order more. - Revision: We only have two boxes left. To solve this shortage, we should order more. - Example: Click next and enter your credentials when prompted. That will take you to the home screen. - Revision: Click next and enter your credentials when prompted. Successfully authenticating will take you to the home screen. - This duplication can feel repetitive when you're writing it, but it won't feel repetitive to your reader—it'll make your writing clearer and easier to follow. - In summary: when editing, look for ways that you can restate your point, clarify, or provide closure for the reader. - Clauses equivalent to "of" and "for" (Apply the principle to the TARGET LANGUAGE): - Instead of using constructions with "of" or "for" (or their equivalents), rewrite the sentence to put more information before the noun. This ordering makes the sentence more efficient. - Example: The manager of the team responsible for marketing - Revision: The marketing team's manager - In the rearranged version above, the reader can more quickly grasp what you mean, instead of having to revise her understanding after each clause. - Split it up - Break up long sentences into multiple shorter sentences. - Also, break up sentences by adding commas where appropriate. For example, I've noticed a trend towards people dropping commas after subordinate clauses. I always add them back when I edit: - Example: If you're looking for me I'll be in my office. - Revision: If you're looking for me, I'll be in my office. - Example: Due to the fog our flight was delayed. - Revision: Due to the fog, our flight was delayed. - Eliminate passive voice - You've heard this advice before. But you should understand why you shouldn't use passive voice in your writing. It's not just "bad style." - Passive voice obscures who or what is performing the action. Rewriting a passive construction to be active almost always makes what you're saying clearer and makes the sentence easier to read, because your reader can attribute the action to the right person or thing. - Example: The fire alarm was pulled and the building was evacuated. - Revision: The fire marshal pulled the alarm and the employees evacuated the building. - Example: Millions of dollars were embezzled from the company. - Revision: Two executives embezzled millions of dollars from the company. - Be aware of your tone - Know what kind of tone you're going for, and be consistent. You can be colloquial or formal, but not both. - Avoid jargon and cliches - In the business world, jargon means things like "deep dive" and "low-hanging fruit". Elsewhere, we love to use cliches. Especially baseball metaphors, for some reason: "step up to the plate", "hit it out of the park", "take a swing at it". - It will always be better and clearer when you say exactly what you mean. Using jargon is lazy, and it assumes that the reader is part of the in-group that uses that jargon (see also: Don't assume knowledge, above). It can be difficult for non-native English speakers (or non-Americans, when it comes to baseball) to follow your writing when you use jargon and cliches. - Example: tl;dr, if you can hack something together by EOD, that would be great. - Revision: Can you deliver a prototype by the end of today? - The original sentence has incomprehensible acronyms and tech slang, and doesn't even sound like a request. The second one is straightforward, and asks for what the writer needs and by when. - Preserves terms developers actually use (e.g., "프로퍼티" over "속성"). Retain **ALL technical terms** (e.g., "singleton" → "싱글톤 (Singleton)", not "단일체" / "middleware" → "미들웨어 (Middleware)"), abbreviations (e.g., API, HTTP), code blocks, and symbols (e.g., `>`, `*`, `#`). When translating technical terms, include the original English term in parentheses after the translated term. - Maintains code/format integrity for technical correctness. **Only translate** comments/strings within code. - **REGIONAL LANGUAGE VARIATIONS**: - If the `TARGET LANGUAGE` includes a specific `Region` (e.g., 'en-US', 'es-MX', 'fr-CA'), the translation MUST be tailored to the linguistic nuances and conventions of that specific region. Pay close attention to regional vocabulary, spelling, grammar, and cultural references to ensure the translation is natural and appropriate for the intended audience in that region. - **NEUTRAL LANGUAGE FOR UNSPECIFIED REGION**: - If the `TARGET LANGUAGE` does not specify a `Region` (e.g., 'en' instead of 'en-US'), the translation should aim for the most globally understood and neutral form of the language. Avoid region-specific idioms, slang, or cultural references unless they are widely understood internationally or are essential to the meaning of the source text and cannot be conveyed otherwise.
 </Translation_Style_Guide>
 
 <Input>
@@ -243,33 +185,34 @@
 		4.  `TARGET MESSAGES` (JSON string: `{ "number": { "ko": "...", "en": "...", "explanation": "..." } }`): The messages requiring translation. **Keys (`"number"`) are sequential integer strings starting from "1" (e.g., "1", "2", "3", ...).**
 </Input>
 
-<Output_Schema>
-		```typescript
-		/**
-			_Represents the structured output for the translation task.
-			_THE FINAL OUTPUT MUST BE ONLY THIS JSON OBJECT.
-			_/
-		interface TranslationOutput {
-			/_*
-				* The translated messages, keyed by the original message number.
-				*Keys MUST be the sequential integer strings from the input TARGET MESSAGES (e.g., "1", "2", "3", ...).
-				* Values MUST be strings or valid Paraglide variant objects (matching/pluralization).
-				*Example (proactive pluralization applied): "4": { "declarations": ["input itemCount", ...], "match": { "countPlural=one": "1 item", "countPlural=other": "{itemCount} items" } }
-				*/
-			translatedMessages: { [messageNumber: string]: string | object };
+<Output*Schema>
+```typescript
+/\*\*
+\_Represents the structured output for the translation task.
+\_THE FINAL OUTPUT MUST BE ONLY THIS JSON OBJECT.
+*/
+interface TranslationOutput {
+/\_\*
+* The translated messages, keyed by the original message number.
+*Keys MUST be the sequential integer strings from the input TARGET MESSAGES (e.g., "1", "2", "3", ...).
+* Values MUST be strings or valid Paraglide variant objects (matching/pluralization).
+*Example (proactive pluralization applied): "4": { "declarations": ["input itemCount", ...], "match": { "countPlural=one": "1 item", "countPlural=other": "{itemCount} items" } }
+\*/
+translatedMessages: { [messageNumber: string]: string | object };
 
-			/**
-				* Newly identified terms and their translations for future consistency.
-				* @additionalProperties {string}
-				* @example { "SourceTerm1": "TranslatedTerm1", "SourceTerm2": "TranslatedTerm2" }
-				*/
-			newDictionary: { [sourceTerm: string]: string };
-		}
-		```
+    		/**
+    			* Newly identified terms and their translations for future consistency.
+    			* @additionalProperties {string}
+    			* @example { "SourceTerm1": "TranslatedTerm1", "SourceTerm2": "TranslatedTerm2" }
+    			*/
+    		newDictionary: { [sourceTerm: string]: string };
+    	}
+    	```
+
 </Output_Schema>
 
 <Example_Final_Output>
-		```json
+`json
 		{
 			"translatedMessages": {
 				"1": "Translated message for 1.",
@@ -291,5 +234,5 @@
 				// ... other new dictionary entries
 			}
 		}
-		```
+		`
 </Example_Final_Output>

--- a/libraries/scripts/src/translation/paraglide/prompt.md
+++ b/libraries/scripts/src/translation/paraglide/prompt.md
@@ -232,9 +232,11 @@
 
 
 
-/\*\*\_Represents the structured output for the translation task.\_THE FINAL OUTPUT MUST BE ONLY THIS JSON OBJECT.*/interface TranslationOutput {/\_\** The translated messages, keyed by the original message number.*Keys MUST be the sequential integer strings from the input TARGET MESSAGES (e.g., "1", "2", "3", ...).* Values MUST be strings or valid Paraglide variant objects (matching/pluralization).*Example (proactive pluralization applied): "4": { "declarations": ["input itemCount", ...], "match": { "countPlural=one": "1 item", "countPlural=other": "{itemCount} items" } }\*/translatedMessages: { [messageNumber: string]: string | object };    		/**    			* Newly identified terms and their translations for future consistency.    			* @additionalProperties {string}    			* @example { "SourceTerm1": "TranslatedTerm1", "SourceTerm2": "TranslatedTerm2" }    			*/    		newDictionary: { [sourceTerm: string]: string };    	}    	```</Output_Schema>
 
-<Example_Final_Output>
+
+
+
+/\*\*\_Represents the structured output for the translation task.\_THE FINAL OUTPUT MUST BE ONLY THIS JSON OBJECT.*/interface TranslationOutput {/\_\** The translated messages, keyed by the original message number.*Keys MUST be the sequential integer strings from the input TARGET MESSAGES (e.g., "1", "2", "3", ...).* Values MUST be strings or valid Paraglide variant objects (matching/pluralization).*Example (proactive pluralization applied): "4": { "declarations": ["input itemCount", ...], "match": { "countPlural=one": "1 item", "countPlural=other": "{itemCount} items" } }\*/translatedMessages: { [messageNumber: string]: string | object };    		/**    			* Newly identified terms and their translations for future consistency.    			* @additionalProperties {string}    			* @example { "SourceTerm1": "TranslatedTerm1", "SourceTerm2": "TranslatedTerm2" }    			*/    		newDictionary: { [sourceTerm: string]: string };    	}    	```</Output_Schema><Example_Final_Output>
 `json
 		{
 			"translatedMessages": {

--- a/libraries/scripts/src/translation/paraglide/prompt.md
+++ b/libraries/scripts/src/translation/paraglide/prompt.md
@@ -228,9 +228,11 @@
 
 
 
-/\*\*\_Represents the structured output for the translation task.\_THE FINAL OUTPUT MUST BE ONLY THIS JSON OBJECT.*/interface TranslationOutput {/\_\** The translated messages, keyed by the original message number.*Keys MUST be the sequential integer strings from the input TARGET MESSAGES (e.g., "1", "2", "3", ...).* Values MUST be strings or valid Paraglide variant objects (matching/pluralization).*Example (proactive pluralization applied): "4": { "declarations": ["input itemCount", ...], "match": { "countPlural=one": "1 item", "countPlural=other": "{itemCount} items" } }\*/translatedMessages: { [messageNumber: string]: string | object };    		/**    			* Newly identified terms and their translations for future consistency.    			* @additionalProperties {string}    			* @example { "SourceTerm1": "TranslatedTerm1", "SourceTerm2": "TranslatedTerm2" }    			*/    		newDictionary: { [sourceTerm: string]: string };    	}    	```
 
-</Output_Schema>
+
+
+
+/\*\*\_Represents the structured output for the translation task.\_THE FINAL OUTPUT MUST BE ONLY THIS JSON OBJECT.*/interface TranslationOutput {/\_\** The translated messages, keyed by the original message number.*Keys MUST be the sequential integer strings from the input TARGET MESSAGES (e.g., "1", "2", "3", ...).* Values MUST be strings or valid Paraglide variant objects (matching/pluralization).*Example (proactive pluralization applied): "4": { "declarations": ["input itemCount", ...], "match": { "countPlural=one": "1 item", "countPlural=other": "{itemCount} items" } }\*/translatedMessages: { [messageNumber: string]: string | object };    		/**    			* Newly identified terms and their translations for future consistency.    			* @additionalProperties {string}    			* @example { "SourceTerm1": "TranslatedTerm1", "SourceTerm2": "TranslatedTerm2" }    			*/    		newDictionary: { [sourceTerm: string]: string };    	}    	```</Output_Schema>
 
 <Example_Final_Output>
 `json

--- a/libraries/scripts/src/translation/paraglide/prompt.md
+++ b/libraries/scripts/src/translation/paraglide/prompt.md
@@ -224,9 +224,11 @@
 
 
 
-/\*\*\_Represents the structured output for the translation task.\_THE FINAL OUTPUT MUST BE ONLY THIS JSON OBJECT.*/interface TranslationOutput {/\_\** The translated messages, keyed by the original message number.*Keys MUST be the sequential integer strings from the input TARGET MESSAGES (e.g., "1", "2", "3", ...).* Values MUST be strings or valid Paraglide variant objects (matching/pluralization).*Example (proactive pluralization applied): "4": { "declarations": ["input itemCount", ...], "match": { "countPlural=one": "1 item", "countPlural=other": "{itemCount} items" } }\*/translatedMessages: { [messageNumber: string]: string | object };    		/**    			* Newly identified terms and their translations for future consistency.    			* @additionalProperties {string}    			* @example { "SourceTerm1": "TranslatedTerm1", "SourceTerm2": "TranslatedTerm2" }    			*/    		newDictionary: { [sourceTerm: string]: string };
-    	}
-    	```
+
+
+
+
+/\*\*\_Represents the structured output for the translation task.\_THE FINAL OUTPUT MUST BE ONLY THIS JSON OBJECT.*/interface TranslationOutput {/\_\** The translated messages, keyed by the original message number.*Keys MUST be the sequential integer strings from the input TARGET MESSAGES (e.g., "1", "2", "3", ...).* Values MUST be strings or valid Paraglide variant objects (matching/pluralization).*Example (proactive pluralization applied): "4": { "declarations": ["input itemCount", ...], "match": { "countPlural=one": "1 item", "countPlural=other": "{itemCount} items" } }\*/translatedMessages: { [messageNumber: string]: string | object };    		/**    			* Newly identified terms and their translations for future consistency.    			* @additionalProperties {string}    			* @example { "SourceTerm1": "TranslatedTerm1", "SourceTerm2": "TranslatedTerm2" }    			*/    		newDictionary: { [sourceTerm: string]: string };    	}    	```
 
 </Output_Schema>
 

--- a/libraries/scripts/src/translation/paraglide/prompt.md
+++ b/libraries/scripts/src/translation/paraglide/prompt.md
@@ -5,176 +5,234 @@
 <Instructions>
 		**Overall Task:** Translate the provided `TARGET MESSAGES` into the specified `TARGET LANGUAGE`, ensuring consistency with `OLDER MESSAGES` and the `DICTIONARY`. The `TARGET MESSAGES` object uses sequential integer strings starting from "1" as keys (e.g., "1", "2", "3", ...). You MUST perform the analysis and translation steps internally as described below. The **FINAL OUTPUT MUST BE ONLY** the JSON object containing `translatedMessages` and `newDictionary`, conforming EXACTLY to the `Output_Schema`. The keys in the `translatedMessages` object MUST correspond to the original sequential keys from `TARGET MESSAGES`.
 
-    	**Internal Process (You MUST explicitly show your thinking process step-by-step for sections 1 and 2 below. This thinking process is NOT part of the final JSON output but is crucial for transparency and verification):**
+		**Internal Process (You MUST explicitly show your thinking process step-by-step for sections 1 and 2 below. This thinking process is NOT part of the final JSON output but is crucial for transparency and verification):**
 
-    	1.  **Understand Task and Inputs:**
-    			*   **(Thinking Step 1 Start) Now I will articulate my understanding of the task and inputs.**
-    			*   Confirm your understanding of the core task, inputs (`TARGET LANGUAGE`, `OLDER MESSAGES`, `DICTIONARY`, `TARGET MESSAGES` with keys "1", "2", ...), and constraints (Paraglide Rules including proactive pluralization, Style Guide, Final Output Format with sequential keys in `translatedMessages`).
-    			*   **(Thinking Step 1 End)**
+		1.  **Understand Task and Inputs:**
+				*   **(Thinking Step 1 Start) Now I will articulate my understanding of the task and inputs.**
+				*   Confirm your understanding of the core task, inputs (`TARGET LANGUAGE`, `OLDER MESSAGES`, `DICTIONARY`, `TARGET MESSAGES` with keys "1", "2", ...), and constraints (Paraglide Rules including proactive pluralization, Style Guide, Final Output Format with sequential keys in `translatedMessages`).
+				*   **(Thinking Step 1 End)**
 
-    	2.  **Analyze Subtle Parts (CRITICAL Internal Thinking Step - `planForSubtleParts`):**
-    			*   **(Thinking Step 2 Start) Now I will analyze subtle parts and formulate a plan.**
-    			*   **You MUST meticulously perform this internal analysis step.**
-    			*   Carefully review ALL `TARGET MESSAGES` corresponding to keys "1", "2", etc.
-    			*   Identify any parts (words, phrases, parameters, message structures) that are particularly subtle, tricky, or require careful handling for the `TARGET LANGUAGE` and style guide. This **MUST include identifying potential needs for proactive pluralization based on parameters** when translating to English or similar languages.
-    			*   For EACH identified part, you MUST internally formulate a detailed plan covering:
-    					*   `part`: The specific part identified.
-    					*   `why`: The reason it's challenging or needs special attention (e.g., nuance, Paraglide rule application, pluralization).
-    					*   `plan`: Your specific strategy for translating it according to all rules and guides.
-    			*   **As part of your internal thinking process, before proceeding to Step 3 (Translate Messages), you MUST explicitly list each identified subtle part and its corresponding `part`, `why`, and `plan` that you have formulated. This explicit listing is for a clear articulation of your internal reasoning process and will NOT be part of the final JSON output.**
-    			*   **Consult the `Paraglide Rules`, `Translation_Style_Guide`, `Input` definitions, and `Examples` extensively when formulating this internal plan.**
-    			*   This detailed internal plan is ESSENTIAL for guiding your translation in Step 3. **It WILL NOT and MUST NOT be part of the final JSON output**, but its thorough execution is mandatory for high-quality translation.
-    			*   **(Thinking Step 2 End)**
+		2.  **Analyze Subtle Parts (CRITICAL Internal Thinking Step - `planForSubtleParts`):**
+				*   **(Thinking Step 2 Start) Now I will analyze subtle parts and formulate a plan.**
+				*   **You MUST meticulously perform this internal analysis step.**
+				*   Carefully review ALL `TARGET MESSAGES` corresponding to keys "1", "2", etc.
+				*   Identify any parts (words, phrases, parameters, message structures) that are particularly subtle, tricky, or require careful handling for the `TARGET LANGUAGE` and style guide. This **MUST include identifying potential needs for proactive pluralization based on parameters** when translating to English or similar languages.
+				*   For EACH identified part, you MUST internally formulate a detailed plan covering:
+						*   `part`: The specific part identified.
+						*   `why`: The reason it's challenging or needs special attention (e.g., nuance, Paraglide rule application, pluralization).
+						*   `plan`: Your specific strategy for translating it according to all rules and guides.
+				*   **As part of your internal thinking process, before proceeding to Step 3 (Translate Messages), you MUST explicitly list each identified subtle part and its corresponding `part`, `why`, and `plan` that you have formulated. This explicit listing is for a clear articulation of your internal reasoning process and will NOT be part of the final JSON output.**
+				*   **Consult the `Paraglide Rules`, `Translation_Style_Guide`, `Input` definitions, and `Examples` extensively when formulating this internal plan.**
+				*   This detailed internal plan is ESSENTIAL for guiding your translation in Step 3. **It WILL NOT and MUST NOT be part of the final JSON output**, but its thorough execution is mandatory for high-quality translation.
+				*   **(Thinking Step 2 End)**
 
-    	3.  **Translate Messages (`translatedMessages`):**
-    			*   Execute the internal translation plan meticulously formulated in Step 2.
-    			*   Translate each message for keys "1", "2", ... **using the provided `ko`, `en`, and `explanation` fields for full context and meaning.**
-    			*   **Actively consult `OLDER MESSAGES` and `DICTIONARY` for consistency.**
-    			*   **CRITICAL: Adhere STRICTLY to the Paraglide Rules (provided below).**
-    					*   Handle parameters (`{}`) correctly.
-    					*   Handle variants (Matching, Pluralization) correctly.
-    					*   **PROACTIVE PLURALIZATION (Especially for English Target):** When translating to English (or other languages requiring grammatical number agreement), analyze parameters (`{paramName}`). If a parameter likely represents a count or countable noun (judging by its name like `{count}`, `{numItems}`, or context from the `explanation`), even if the source (e.g., Korean) doesn't show plural variation, **YOU MUST proactively apply the Paraglide pluralization structure.**
-    							*   This typically involves adding:
-    									*   `"declarations": ["input paramName", "local countPlural = paramName: plural"]`
-    									*   `"selectors": ["countPlural"]`
-    									*   `"match": { "countPlural=one": "...", "countPlural=other": "..." }` using `paramName` appropriately in the translated strings.
-    							*   Use the `explanation` and common sense to determine if a parameter requires this proactive pluralization.
-    					*   Ensure correct application of `Intl.PluralRules` for the **specified `TARGET LANGUAGE`**'s plural categories.
-    			*   **CRITICAL: Adhere STRICTLY to the Translation Style Guide (provided below).**
-    			*   The results of this step will form the `translatedMessages` object in the final JSON, using the original sequential keys ("1", "2", ...).
+		3.  **Translate Messages (`translatedMessages`):**
+				*   Execute the internal translation plan meticulously formulated in Step 2.
+				*   Translate each message for keys "1", "2", ... **using the provided `ko`, `en`, and `explanation` fields for full context and meaning.**
+				*   **Actively consult `OLDER MESSAGES` and `DICTIONARY` for consistency.**
+				*   **CRITICAL: Adhere STRICTLY to the Paraglide Rules (provided below).**
+						*   Handle parameters (`{}`) correctly.
+						*   Handle variants (Matching, Pluralization) correctly.
+						*   **PROACTIVE PLURALIZATION (Especially for English Target):** When translating to English (or other languages requiring grammatical number agreement), analyze parameters (`{paramName}`). If a parameter likely represents a count or countable noun (judging by its name like `{count}`, `{numItems}`, or context from the `explanation`), even if the source (e.g., Korean) doesn't show plural variation, **YOU MUST proactively apply the Paraglide pluralization structure.**
+								*   This typically involves adding:
+										*   `"declarations": ["input paramName", "local countPlural = paramName: plural"]`
+										*   `"selectors": ["countPlural"]`
+										*   `"match": { "countPlural=one": "...", "countPlural=other": "..." }` using `paramName` appropriately in the translated strings.
+								*   Use the `explanation` and common sense to determine if a parameter requires this proactive pluralization.
+						*   Ensure correct application of `Intl.PluralRules` for the **specified `TARGET LANGUAGE`**'s plural categories.
+				*   **CRITICAL: Adhere STRICTLY to the Translation Style Guide (provided below).**
+				*   The results of this step will form the `translatedMessages` object in the final JSON, using the original sequential keys ("1", "2", ...).
 
-    	4.  **Generate New Dictionary (`newDictionary`):**
-    			*   Review the translations produced in Step 3.
-    			*   Identify new or significant translated terms.
-    			*   Internally create the `newDictionary` object (`{ "source term": "translated term" }`). This will be the `newDictionary` part of the final JSON.
-    			*   **CRITICAL: Only add terms that are essential for maintaining translation consistency across future messages. This can include menu names that are referenced in multiple UI texts and require consistent naming. If no such terms are identified, return an empty object (`{}`).**
+		4.  **Generate New Dictionary (`newDictionary`):**
+				*   Review the translations produced in Step 3.
+				*   Identify new or significant translated terms.
+				*   Internally create the `newDictionary` object (`{ "source term": "translated term" }`). This will be the `newDictionary` part of the final JSON.
+				*   **CRITICAL: Only add terms that are essential for maintaining translation consistency across future messages. This can include menu names that are referenced in multiple UI texts and require consistent naming. If no such terms are identified, return an empty object (`{}`).**
 
-    	5.  **Format and Output Final JSON:**
-    			*   Combine `translatedMessages` (from Step 3) and `newDictionary` (from Step 4) into a single JSON object.
-    			*   Ensure this JSON object conforms EXACTLY to the `Output_Schema` (which no longer includes `planForSubtleParts`).
-    			*   Ensure the keys in the `translatedMessages` object are the sequential integer strings "1", "2", "3", ... corresponding to the input.
-    			*   **OUTPUT ONLY THIS FINAL JSON OBJECT.** NO other text, explanation, reasoning, or introductory phrases should precede or follow the JSON output.
+		5.  **Format and Output Final JSON:**
+				*   Combine `translatedMessages` (from Step 3) and `newDictionary` (from Step 4) into a single JSON object.
+				*   Ensure this JSON object conforms EXACTLY to the `Output_Schema` (which no longer includes `planForSubtleParts`).
+				*   Ensure the keys in the `translatedMessages` object are the sequential integer strings "1", "2", "3", ... corresponding to the input.
+				*   **OUTPUT ONLY THIS FINAL JSON OBJECT.** NO other text, explanation, reasoning, or introductory phrases should precede or follow the JSON output.
 
-    	**Paraglide Rules (MUST FOLLOW):**
-    	```text
-    	- The translations you produce MUST follow the inlang message format for the Paraglide Web App translation library.
-    	- If a word is enclosed in `{` and `}`, it signifies a parameter receiving a value from outside. This part MUST NOT be translated and MUST be left as is, so it can receive an argument with a matching name externally.
-    	- Regarding Variants:
-    		# Variants
+		**Paraglide Rules (MUST FOLLOW):**
+		```text
+		- The translations you produce MUST follow the inlang message format for the Paraglide Web App translation library.
+		- If a word is enclosed in `{` and `}`, it signifies a parameter receiving a value from outside. This part MUST NOT be translated and MUST be left as is, so it can receive an argument with a matching name externally.
+		- Regarding Variants:
+			# Variants
 
-    		Variants enable pluralization, gendering, A/B testing, and more. They are a powerful feature of inlang that allows you to create different versions of a message based on conditions.
+			Variants enable pluralization, gendering, A/B testing, and more. They are a powerful feature of inlang that allows you to create different versions of a message based on conditions.
 
-    		## Matching
+			## Matching
 
-    		The message below will match the following conditions:
+			The message below will match the following conditions:
 
-    		| Platform | User Gender | Message |
-    		| --- | --- | --- |
-    		| android | male | {username} has to download the app on his phone from the Google Play Store. |
-    		| ios | female | {username} has to download the app on her iPhone from the App Store. |
-    		| \* | \* | The person has to download the app. |
+			| Platform | User Gender | Message |
+			| --- | --- | --- |
+			| android | male | {username} has to download the app on his phone from the Google Play Store. |
+			| ios | female | {username} has to download the app on her iPhone from the App Store. |
+			| \* | \* | The person has to download the app. |
 
-    		The example below uses the inlang message format plugin for illustrative purposes. The syntax may differ depending on the plugin you are using.
+			The example below uses the inlang message format plugin for illustrative purposes. The syntax may differ depending on the plugin you are using.
 
-    		```json
-    				{
-    					"jojo_mountain_day": [{
-    						"match": {
-    							"platform=android, userGender=male": "{username} has to download the app on his phone from the Google Play Store.",
-    							"platform=ios, userGender=female": "{username} has to download the app on her iPhone from the App Store.",
-    							"platform=*, userGender=*": "The person has to download the app."
-    						}
-    					}]
-    				}
-    		```
+			```json
+					{
+						"jojo_mountain_day": [{
+							"match": {
+								"platform=android, userGender=male": "{username} has to download the app on his phone from the Google Play Store.",
+								"platform=ios, userGender=female": "{username} has to download the app on her iPhone from the App Store.",
+								"platform=*, userGender=*": "The person has to download the app."
+							}
+						}]
+					}
+			```
 
-    		## Pluralization
+			## Pluralization
 
-    		You can define a variable in your message and then use it in the selector. Paraglide uses `Intl.PluralRules` under the hood to determine the plural form.
+			You can define a variable in your message and then use it in the selector. Paraglide uses `Intl.PluralRules` under the hood to determine the plural form.
 
-    		| Inputs | Condition | Message |
-    		| --- | --- | --- |
-    		| count=1 | countPlural=one | There is one cat. |
-    		| count>1 | countPlural=other | There are many cats. |
+			| Inputs | Condition | Message |
+			| --- | --- | --- |
+			| count=1 | countPlural=one | There is one cat. |
+			| count>1 | countPlural=other | There are many cats. |
 
-    		Read the `local countPlural = count: plural` syntax as "create a local variable `countPlural` that equals `plural(count)`".
+			Read the `local countPlural = count: plural` syntax as "create a local variable `countPlural` that equals `plural(count)`".
 
-    		```json
-    				{
-    				"some_happy_cat": [{
-    						"declarations": ["input count", "local countPlural = count: plural"],
-    						"selectors": ["countPlural"],
-    						"match": {
-    							"countPlural=one": "There is one cat.",
-    							"countPlural=other": "There are many cats.",
-    						},
-    					}]
-    				}
-    		```
+			```json
+					{
+					"some_happy_cat": [{
+							"declarations": ["input count", "local countPlural = count: plural"],
+							"selectors": ["countPlural"],
+							"match": {
+								"countPlural=one": "There is one cat.",
+								"countPlural=other": "There are many cats.",
+							},
+						}]
+					}
+			```
 
-    		### 1. Matching (Explanation)
+			### 1. Matching (Explanation)
 
-    		Use this when you want to display different messages based on conditions. Define the condition and the corresponding message within the `match` object.
+			Use this when you want to display different messages based on conditions. Define the condition and the corresponding message within the `match` object.
 
-    		**Example:**
+			**Example:**
 
-    		The following JSON format shows different download instruction messages based on the user's platform and gender.
+			The following JSON format shows different download instruction messages based on the user's platform and gender.
 
-    		```json
-    		// Example: Branching messages based on platform and gender
-    		{
-    			"jojo_mountain_day": [{
-    				"match": {
-    					"platform=android, userGender=male": "{username} has to download the app on his phone from the Google Play Store.",
-    					"platform=ios, userGender=female": "{username} has to download the app on her iPhone from the App Store.",
-    					"platform=*, userGender=*": "The person has to download the app."
-    				}
-    			}]
-    		}
-    		```
+			```json
+			// Example: Branching messages based on platform and gender
+			{
+				"jojo_mountain_day": [{
+					"match": {
+						"platform=android, userGender=male": "{username} has to download the app on his phone from the Google Play Store.",
+						"platform=ios, userGender=female": "{username} has to download the app on her iPhone from the App Store.",
+						"platform=*, userGender=*": "The person has to download the app."
+					}
+				}]
+			}
+			```
 
-    		- Keys within the `match` object define conditions in the format `variableName=value`. Multiple conditions can be combined using a comma (`,`).
-    		- `platform=android, userGender=male` specifies the message for when the platform is 'android' and the user gender is 'male'.
-    		- An asterisk (`*`) acts as a wildcard, used to set a default message for all cases not covered by other specific conditions.
+			- Keys within the `match` object define conditions in the format `variableName=value`. Multiple conditions can be combined using a comma (`,`).
+			- `platform=android, userGender=male` specifies the message for when the platform is 'android' and the user gender is 'male'.
+			- An asterisk (`*`) acts as a wildcard, used to set a default message for all cases not covered by other specific conditions.
 
-    		### 2. Pluralization (Explanation)
+			### 2. Pluralization (Explanation)
 
-    		Use this to display different messages based on quantity. Paraglide internally uses `Intl.PluralRules` to handle pluralization rules.
+			Use this to display different messages based on quantity. Paraglide internally uses `Intl.PluralRules` to handle pluralization rules.
 
-    		**Example:**
+			**Example:**
 
-    		Shows different messages based on the number of cats (`count`).
+			Shows different messages based on the number of cats (`count`).
 
-    		```json
-    		// Example: Branching messages based on the number of cats
-    		{
-    		"some_happy_cat": [{
-    				// Declare input variable 'count' and local variable 'countPlural'
-    				"declarations": ["input count", "local countPlural = count: plural"],
-    				// Use the 'countPlural' variable as the selection criterion
-    				"selectors": ["countPlural"],
-    				"match": {
-    					// When count is 1 (plural rule: 'one')
-    					"countPlural=one": "There is one cat.",
-    					// When count is not 1 (plural rule: 'other')
-    					"countPlural=other": "There are many cats."
-    				},
-    			}]
-    		}
-    		```
+			```json
+			// Example: Branching messages based on the number of cats
+			{
+			"some_happy_cat": [{
+					// Declare input variable 'count' and local variable 'countPlural'
+					"declarations": ["input count", "local countPlural = count: plural"],
+					// Use the 'countPlural' variable as the selection criterion
+					"selectors": ["countPlural"],
+					"match": {
+						// When count is 1 (plural rule: 'one')
+						"countPlural=one": "There is one cat.",
+						// When count is not 1 (plural rule: 'other')
+						"countPlural=other": "There are many cats."
+					},
+				}]
+			}
+			```
 
-    		- `declarations`: Declares variables to be used within the message.
-    				- `input count`: Declares an input variable named `count`. This variable receives its value from outside.
-    				- `local countPlural = count: plural`: Applies the `plural` function (internally using `Intl.PluralRules`) to the `count` variable and stores the result in a local variable named `countPlural`. This variable will hold a value corresponding to the language's plural rule ('one', 'other', 'few', 'many', etc.).
-    		- `selectors`: Specifies which variable(s) to use as the basis for branching in the `match` object. Here, `countPlural` is used.
-    		- `match`: Specifies different messages based on the value of the `countPlural` variable. For English, this is typically distinguished as 'one' and 'other'.
+			- `declarations`: Declares variables to be used within the message.
+					- `input count`: Declares an input variable named `count`. This variable receives its value from outside.
+					- `local countPlural = count: plural`: Applies the `plural` function (internally using `Intl.PluralRules`) to the `count` variable and stores the result in a local variable named `countPlural`. This variable will hold a value corresponding to the language's plural rule ('one', 'other', 'few', 'many', etc.).
+			- `selectors`: Specifies which variable(s) to use as the basis for branching in the `match` object. Here, `countPlural` is used.
+			- `match`: Specifies different messages based on the value of the `countPlural` variable. For English, this is typically distinguished as 'one' and 'other'.
 
-    							**Important Note on Proactive Pluralization:** When translating *into* languages like English from languages that may not explicitly mark plurals in the source text (e.g., Korean), you MUST proactively analyze parameters (`{paramName}`). If context (parameter name, explanation) suggests `paramName` represents a countable quantity, apply the pluralization structure (`declarations`, `selectors`, `match`) using `paramName` as the input, even if the source text doesn't vary.
-    	```
-
+								**Important Note on Proactive Pluralization:** When translating *into* languages like English from languages that may not explicitly mark plurals in the source text (e.g., Korean), you MUST proactively analyze parameters (`{paramName}`). If context (parameter name, explanation) suggests `paramName` represents a countable quantity, apply the pluralization structure (`declarations`, `selectors`, `match`) using `paramName` as the input, even if the source text doesn't vary.
+		```
 </Instructions>
 
-<Translation_Style_Guide> - Keep in mind that the translation target is UI text. The translation must properly convey the intended function of the message in the UI!!! - The most important thing is to convey the meaning of the TARGET MESSAGES well without damaging it! - DON'T OMIT **ANYTHING** FROM THE ORIGINAL CONTENT! - Faithfully preserve every point of the original source text (Korean/English) in the translation and its unique metaphors. Do not alter or omit any point of the original content. - If direct translation struggles to capture the full meaning and nuance of the original sentence in the target language without loss, you MAY elaborate or add necessary context in the translated sentence to ensure the original intent and subtlety are fully conveyed. Prioritize faithful representation over strict literalism when such additions are crucial for preserving meaning. - YOU MUST NOT NORMALIZE WEIRD, BIZARRE, HARSH, CONTROVERSIAL, AGGRESSIVE, OR EXTREME WORDS, SENTENCES, PARAGRAPHS, METAPHORS, ANALOGIES, AND EXAMPLES! - DON'T ADD METAPHORS THAT WEREN'T IN THE ORIGINAL TEXT. DON'T TRY TO DO OR ADD SOMETHING, JUST DO A GOOD JOB OF REPRESENTING AND GLUING THE TEXT THAT WAS ORIGINALLY GIVEN TO YOU. - DON'T SOUND LIKE A MARKETER! DON'T WRITE TO SOUND LIKE MARKETING! - USE ONLY THE EASIEST SENTENCES YOU CAN! - NEVER USE UNNECESSARILY DIFFICULT WORDS. DON'T USE UNNECESSARILY COMPLEX EXPRESSIONS. IF SOMETHING CAN BE EXPRESSED WITH EASIER WORDS AND SIMPLER EXPRESSIONS, ALWAYS USE EASIER WORDS AND SIMPLER EXPRESSIONS. ALWAYS, IN EVERY PART OF YOUR WRITING. - NEVER, EVER EMBELLISH YOUR WORDS, KEEP IT SIMPLE AND CLEAN. NEVER ADD ANY NEW METAPHORS. NEVER USE UNNECESSARILY DIFFICULT WORDS. DON'T USE UNNECESSARILY COMPLEX EXPRESSIONS. IF SOMETHING CAN BE EXPRESSED WITH EASIER WORDS AND SIMPLER EXPRESSIONS, ALWAYS USE EASIER WORDS AND SIMPLER EXPRESSIONS. ALWAYS, IN EVERY PART OF YOUR WRITING. - OMIT your unnecessary padding out, superfluity, or fluff. Especially in the START and the END of your writing. Begin your writing with THE CORE content. - Write in the style of "Paul Graham": Remember, Paul Graham advocates for writing that is as natural and straightforward as speaking. Avoid overly formal or complex language. Use simple, direct phrases and everyday vocabulary. - Vary sentence length and structure to maintain a dynamic, engaging rhythm - Use short paragraphs (2-4 sentences) to maintain a fast, engaging pace. - **Honest and Direct:** Address topics head-on, without shying away from potentially uncomfortable truths. The writing should reflect a willingness to dive into the heart of the matter - **Conversational Intelligence:** Write like you're explaining a concept to a smart friend. It's informative but not dry; engaging but not flippant. Avoid jargon unless it adds real value, and always explain it. - Break down complex concepts into easily understandable segments. - Repeat yourself (within reason) - Even if you think you've made your point very clearly, it's worth restating it at the beginning and end of what you're writing to make sure the reader gets it. - Example: We only have two boxes left. To solve this, we should order more. - Revision: We only have two boxes left. To solve this shortage, we should order more. - Example: Click next and enter your credentials when prompted. That will take you to the home screen. - Revision: Click next and enter your credentials when prompted. Successfully authenticating will take you to the home screen. - This duplication can feel repetitive when you're writing it, but it won't feel repetitive to your reader—it'll make your writing clearer and easier to follow. - In summary: when editing, look for ways that you can restate your point, clarify, or provide closure for the reader. - Clauses equivalent to "of" and "for" (Apply the principle to the TARGET LANGUAGE): - Instead of using constructions with "of" or "for" (or their equivalents), rewrite the sentence to put more information before the noun. This ordering makes the sentence more efficient. - Example: The manager of the team responsible for marketing - Revision: The marketing team's manager - In the rearranged version above, the reader can more quickly grasp what you mean, instead of having to revise her understanding after each clause. - Split it up - Break up long sentences into multiple shorter sentences. - Also, break up sentences by adding commas where appropriate. For example, I've noticed a trend towards people dropping commas after subordinate clauses. I always add them back when I edit: - Example: If you're looking for me I'll be in my office. - Revision: If you're looking for me, I'll be in my office. - Example: Due to the fog our flight was delayed. - Revision: Due to the fog, our flight was delayed. - Eliminate passive voice - You've heard this advice before. But you should understand why you shouldn't use passive voice in your writing. It's not just "bad style." - Passive voice obscures who or what is performing the action. Rewriting a passive construction to be active almost always makes what you're saying clearer and makes the sentence easier to read, because your reader can attribute the action to the right person or thing. - Example: The fire alarm was pulled and the building was evacuated. - Revision: The fire marshal pulled the alarm and the employees evacuated the building. - Example: Millions of dollars were embezzled from the company. - Revision: Two executives embezzled millions of dollars from the company. - Be aware of your tone - Know what kind of tone you're going for, and be consistent. You can be colloquial or formal, but not both. - Avoid jargon and cliches - In the business world, jargon means things like "deep dive" and "low-hanging fruit". Elsewhere, we love to use cliches. Especially baseball metaphors, for some reason: "step up to the plate", "hit it out of the park", "take a swing at it". - It will always be better and clearer when you say exactly what you mean. Using jargon is lazy, and it assumes that the reader is part of the in-group that uses that jargon (see also: Don't assume knowledge, above). It can be difficult for non-native English speakers (or non-Americans, when it comes to baseball) to follow your writing when you use jargon and cliches. - Example: tl;dr, if you can hack something together by EOD, that would be great. - Revision: Can you deliver a prototype by the end of today? - The original sentence has incomprehensible acronyms and tech slang, and doesn't even sound like a request. The second one is straightforward, and asks for what the writer needs and by when. - Preserves terms developers actually use (e.g., "프로퍼티" over "속성"). Retain **ALL technical terms** (e.g., "singleton" → "싱글톤 (Singleton)", not "단일체" / "middleware" → "미들웨어 (Middleware)"), abbreviations (e.g., API, HTTP), code blocks, and symbols (e.g., `>`, `*`, `#`). When translating technical terms, include the original English term in parentheses after the translated term. - Maintains code/format integrity for technical correctness. **Only translate** comments/strings within code. - **REGIONAL LANGUAGE VARIATIONS**: - If the `TARGET LANGUAGE` includes a specific `Region` (e.g., 'en-US', 'es-MX', 'fr-CA'), the translation MUST be tailored to the linguistic nuances and conventions of that specific region. Pay close attention to regional vocabulary, spelling, grammar, and cultural references to ensure the translation is natural and appropriate for the intended audience in that region. - **NEUTRAL LANGUAGE FOR UNSPECIFIED REGION**: - If the `TARGET LANGUAGE` does not specify a `Region` (e.g., 'en' instead of 'en-US'), the translation should aim for the most globally understood and neutral form of the language. Avoid region-specific idioms, slang, or cultural references unless they are widely understood internationally or are essential to the meaning of the source text and cannot be conveyed otherwise.
+<Translation_Style_Guide>
+		- Keep in mind that the translation target is UI text. The translation must properly convey the intended function of the message in the UI!!!
+		- The most important thing is to convey the meaning of the TARGET MESSAGES well without damaging it!
+				- DON'T OMIT **ANYTHING** FROM THE ORIGINAL CONTENT!
+				- Faithfully preserve every point of the original source text (Korean/English) in the translation and its unique metaphors. Do not alter or omit any point of the original content.
+				- If direct translation struggles to capture the full meaning and nuance of the original sentence in the target language without loss, you MAY elaborate or add necessary context in the translated sentence to ensure the original intent and subtlety are fully conveyed. Prioritize faithful representation over strict literalism when such additions are crucial for preserving meaning.
+				- YOU MUST NOT NORMALIZE WEIRD, BIZARRE, HARSH, CONTROVERSIAL, AGGRESSIVE, OR EXTREME WORDS, SENTENCES, PARAGRAPHS, METAPHORS, ANALOGIES, AND EXAMPLES!
+				- DON'T ADD METAPHORS THAT WEREN'T IN THE ORIGINAL TEXT. DON'T TRY TO DO OR ADD SOMETHING, JUST DO A GOOD JOB OF REPRESENTING AND GLUING THE TEXT THAT WAS ORIGINALLY GIVEN TO YOU.
+		- DON'T SOUND LIKE A MARKETER! DON'T WRITE TO SOUND LIKE MARKETING!
+		- USE ONLY THE EASIEST SENTENCES YOU CAN!
+				- NEVER USE UNNECESSARILY DIFFICULT WORDS. DON'T USE UNNECESSARILY COMPLEX EXPRESSIONS. IF SOMETHING CAN BE EXPRESSED WITH EASIER WORDS AND SIMPLER EXPRESSIONS, ALWAYS USE EASIER WORDS AND SIMPLER EXPRESSIONS. ALWAYS, IN EVERY PART OF YOUR WRITING.
+				- NEVER, EVER EMBELLISH YOUR WORDS, KEEP IT SIMPLE AND CLEAN. NEVER ADD ANY NEW METAPHORS. NEVER USE UNNECESSARILY DIFFICULT WORDS. DON'T USE UNNECESSARILY COMPLEX EXPRESSIONS. IF SOMETHING CAN BE EXPRESSED WITH EASIER WORDS AND SIMPLER EXPRESSIONS, ALWAYS USE EASIER WORDS AND SIMPLER EXPRESSIONS. ALWAYS, IN EVERY PART OF YOUR WRITING.
+		- OMIT your unnecessary padding out, superfluity, or fluff. Especially in the START and the END of your writing. Begin your writing with THE CORE content.
+		- Write in the style of "Paul Graham": Remember, Paul Graham advocates for writing that is as natural and straightforward as speaking. Avoid overly formal or complex language. Use simple, direct phrases and everyday vocabulary.
+		- Vary sentence length and structure to maintain a dynamic, engaging rhythm
+		- Use short paragraphs (2-4 sentences) to maintain a fast, engaging pace.
+		- **Honest and Direct:** Address topics head-on, without shying away from potentially uncomfortable truths. The writing should reflect a willingness to dive into the heart of the matter
+		- **Conversational Intelligence:** Write like you're explaining a concept to a smart friend. It's informative but not dry; engaging but not flippant. Avoid jargon unless it adds real value, and always explain it.
+		- Break down complex concepts into easily understandable segments.
+		- Repeat yourself (within reason)
+				- Even if you think you've made your point very clearly, it's worth restating it at the beginning and end of what you're writing to make sure the reader gets it.
+				- Example: We only have two boxes left. To solve this, we should order more.
+				- Revision: We only have two boxes left. To solve this shortage, we should order more.
+				- Example: Click next and enter your credentials when prompted. That will take you to the home screen.
+				- Revision: Click next and enter your credentials when prompted. Successfully authenticating will take you to the home screen.
+				- This duplication can feel repetitive when you're writing it, but it won't feel repetitive to your reader—it'll make your writing clearer and easier to follow.
+				- In summary: when editing, look for ways that you can restate your point, clarify, or provide closure for the reader.
+		- Clauses equivalent to "of" and "for" (Apply the principle to the TARGET LANGUAGE):
+				- Instead of using constructions with "of" or "for" (or their equivalents), rewrite the sentence to put more information before the noun. This ordering makes the sentence more efficient.
+				- Example: The manager of the team responsible for marketing
+				- Revision: The marketing team's manager
+				- In the rearranged version above, the reader can more quickly grasp what you mean, instead of having to revise her understanding after each clause.
+		- Split it up
+				- Break up long sentences into multiple shorter sentences.
+				- Also, break up sentences by adding commas where appropriate. For example, I've noticed a trend towards people dropping commas after subordinate clauses. I always add them back when I edit:
+				- Example: If you're looking for me I'll be in my office.
+				- Revision: If you're looking for me, I'll be in my office.
+				- Example: Due to the fog our flight was delayed.
+				- Revision: Due to the fog, our flight was delayed.
+		- Eliminate passive voice
+				- You've heard this advice before. But you should understand why you shouldn't use passive voice in your writing. It's not just "bad style."
+				- Passive voice obscures who or what is performing the action. Rewriting a passive construction to be active almost always makes what you're saying clearer and makes the sentence easier to read, because your reader can attribute the action to the right person or thing.
+				- Example: The fire alarm was pulled and the building was evacuated.
+				- Revision: The fire marshal pulled the alarm and the employees evacuated the building.
+				- Example: Millions of dollars were embezzled from the company.
+				- Revision: Two executives embezzled millions of dollars from the company.
+		- Be aware of your tone
+				- Know what kind of tone you're going for, and be consistent. You can be colloquial or formal, but not both.
+		- Avoid jargon and cliches
+				- In the business world, jargon means things like "deep dive" and "low-hanging fruit". Elsewhere, we love to use cliches. Especially baseball metaphors, for some reason: "step up to the plate", "hit it out of the park", "take a swing at it".
+				- It will always be better and clearer when you say exactly what you mean. Using jargon is lazy, and it assumes that the reader is part of the in-group that uses that jargon (see also: Don't assume knowledge, above). It can be difficult for non-native English speakers (or non-Americans, when it comes to baseball) to follow your writing when you use jargon and cliches.
+				- Example: tl;dr, if you can hack something together by EOD, that would be great.
+				- Revision: Can you deliver a prototype by the end of today?
+				- The original sentence has incomprehensible acronyms and tech slang, and doesn't even sound like a request. The second one is straightforward, and asks for what the writer needs and by when.
+		- Preserves terms developers actually use (e.g., "프로퍼티" over "속성"). Retain **ALL technical terms** (e.g., "singleton" → "싱글톤 (Singleton)", not "단일체" / "middleware" → "미들웨어 (Middleware)"), abbreviations (e.g., API, HTTP), code blocks, and symbols (e.g., `>`, `*`, `#`). When translating technical terms, include the original English term in parentheses after the translated term.
+		- Maintains code/format integrity for technical correctness. **Only translate** comments/strings within code.
+		- **REGIONAL LANGUAGE VARIATIONS**:
+				- If the `TARGET LANGUAGE` includes a specific `Region` (e.g., 'en-US', 'es-MX', 'fr-CA'), the translation MUST be tailored to the linguistic nuances and conventions of that specific region. Pay close attention to regional vocabulary, spelling, grammar, and cultural references to ensure the translation is natural and appropriate for the intended audience in that region.
+		- **NEUTRAL LANGUAGE FOR UNSPECIFIED REGION**:
+				- If the `TARGET LANGUAGE` does not specify a `Region` (e.g., 'en' instead of 'en-US'), the translation should aim for the most globally understood and neutral form of the language. Avoid region-specific idioms, slang, or cultural references unless they are widely understood internationally or are essential to the meaning of the source text and cannot be conveyed otherwise.
 </Translation_Style_Guide>
 
 <Input>
@@ -185,59 +243,33 @@
 		4.  `TARGET MESSAGES` (JSON string: `{ "number": { "ko": "...", "en": "...", "explanation": "..." } }`): The messages requiring translation. **Keys (`"number"`) are sequential integer strings starting from "1" (e.g., "1", "2", "3", ...).**
 </Input>
 
-<Output\*Schema>
+<Output_Schema>
+		```typescript
+		/**
+			_Represents the structured output for the translation task.
+			_THE FINAL OUTPUT MUST BE ONLY THIS JSON OBJECT.
+			_/
+		interface TranslationOutput {
+			/_*
+				* The translated messages, keyed by the original message number.
+				*Keys MUST be the sequential integer strings from the input TARGET MESSAGES (e.g., "1", "2", "3", ...).
+				* Values MUST be strings or valid Paraglide variant objects (matching/pluralization).
+				*Example (proactive pluralization applied): "4": { "declarations": ["input itemCount", ...], "match": { "countPlural=one": "1 item", "countPlural=other": "{itemCount} items" } }
+				*/
+			translatedMessages: { [messageNumber: string]: string | object };
 
-````typescript
+			/**
+				* Newly identified terms and their translations for future consistency.
+				* @additionalProperties {string}
+				* @example { "SourceTerm1": "TranslatedTerm1", "SourceTerm2": "TranslatedTerm2" }
+				*/
+			newDictionary: { [sourceTerm: string]: string };
+		}
+		```
+</Output_Schema>
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-/\*\*\_Represents the structured output for the translation task.\_THE FINAL OUTPUT MUST BE ONLY THIS JSON OBJECT.*/interface TranslationOutput {/\_\** The translated messages, keyed by the original message number.*Keys MUST be the sequential integer strings from the input TARGET MESSAGES (e.g., "1", "2", "3", ...).* Values MUST be strings or valid Paraglide variant objects (matching/pluralization).*Example (proactive pluralization applied): "4": { "declarations": ["input itemCount", ...], "match": { "countPlural=one": "1 item", "countPlural=other": "{itemCount} items" } }\*/translatedMessages: { [messageNumber: string]: string | object };    		/**    			* Newly identified terms and their translations for future consistency.    			* @additionalProperties {string}    			* @example { "SourceTerm1": "TranslatedTerm1", "SourceTerm2": "TranslatedTerm2" }    			*/    		newDictionary: { [sourceTerm: string]: string };    	}    	```</Output_Schema><Example_Final_Output>
-`json
+<Example_Final_Output>
+		```json
 		{
 			"translatedMessages": {
 				"1": "Translated message for 1.",
@@ -259,6 +291,5 @@
 				// ... other new dictionary entries
 			}
 		}
-		`
+		```
 </Example_Final_Output>
-````

--- a/turbo.json
+++ b/turbo.json
@@ -30,7 +30,7 @@
 				"$TURBO_DEFAULT$",
 				"!**/*.stories.*"
 			],
-			"outputs": ["dist/**", ".svelte-kit/**", "storybook-static/**", "paraglide-output/**"]
+			"outputs": [".svelte-kit/**"]
 		},
 		"change-base-locale:en": {},
 		"change-base-locale:ko": {},


### PR DESCRIPTION
turbo.json의 outputs 배열에서 dist/**, storybook-static/**, paraglide-output/** 경로를 제거하고 .svelte-kit/**만 남김.  
빌드 출력 경로를 간소화하여 캐시 관리 및 빌드 효율성 개선 목적.