### PR TITLE
fix(ci): dependabot 조건에서 불필요한 필터 제거

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -45,14 +45,12 @@ jobs:
       contents: write
       pull-requests: write
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'dependabot') &&
-      github.event.action == 'labeled' && github.event.label.name == 'mutation-finished'
+      !contains(github.event.pull_request.labels.*.name, 'dependabot')
 
     steps:
       - uses: reitermarkus/automerge@v2
         with:
           token: ${{ secrets.TOKEN1 }}
-          required-labels: mutation-finished
           do-not-merge-labels: never-merge
 
   automerge-dependabot:
@@ -62,8 +60,7 @@ jobs:
       contents: write
       pull-requests: write
     if: |
-      contains(github.event.pull_request.labels.*.name, 'dependabot') &&
-      github.event.action == 'labeled' && github.event.label.name == 'mutation-finished'
+      contains(github.event.pull_request.labels.*.name, 'dependabot')
 
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
.github/workflows/auto_merge.yml 내 자동 병합 조건에서
pull_request 라벨과 액션 조건 일부를 제거하여 조건