### PR TITLE
refactor(ui): iconify-icon 컴포넌트에서 height, width 속성 제거

### DIFF
--- a/libraries/ui/src/shadcn/components/ui/accordion/accordion-trigger.svelte
+++ b/libraries/ui/src/shadcn/components/ui/accordion/accordion-trigger.svelte
@@ -33,9 +33,7 @@ let {
 		<iconify-icon
 			class="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform
 				duration-200"
-			height="16"
 			icon="lucide:chevron-down"
-			width="16"
 		></iconify-icon>
 	</AccordionPrimitive.Trigger>
 </AccordionPrimitive.Header>

--- a/libraries/ui/src/shadcn/components/ui/breadcrumb/breadcrumb-ellipsis.svelte
+++ b/libraries/ui/src/shadcn/components/ui/breadcrumb/breadcrumb-ellipsis.svelte
@@ -20,6 +20,6 @@ let {
 	role="presentation"
 	{...restProps}
 >
-	<iconify-icon height="16" icon="lucide:more-horizontal" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:more-horizontal"></iconify-icon>
 	<span class="sr-only">More</span>
 </span>

--- a/libraries/ui/src/shadcn/components/ui/breadcrumb/breadcrumb-separator.svelte
+++ b/libraries/ui/src/shadcn/components/ui/breadcrumb/breadcrumb-separator.svelte
@@ -24,6 +24,6 @@ let {
 	{#if children}
 		{@render children?.()}
 	{:else}
-		<iconify-icon height="16" icon="lucide:chevron-right" width="16"></iconify-icon>
+		<iconify-icon icon="lucide:chevron-right"></iconify-icon>
 	{/if}
 </li>

--- a/libraries/ui/src/shadcn/components/ui/calendar/calendar-next-button.svelte
+++ b/libraries/ui/src/shadcn/components/ui/calendar/calendar-next-button.svelte
@@ -15,7 +15,7 @@ let {
 </script>
 
 {#snippet Fallback()}
-	<iconify-icon height="16" icon="lucide:chevron-right" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:chevron-right"></iconify-icon>
 {/snippet}
 
 <CalendarPrimitive.NextButton

--- a/libraries/ui/src/shadcn/components/ui/calendar/calendar-prev-button.svelte
+++ b/libraries/ui/src/shadcn/components/ui/calendar/calendar-prev-button.svelte
@@ -15,7 +15,7 @@ let {
 </script>
 
 {#snippet Fallback()}
-	<iconify-icon height="16" icon="lucide:chevron-left" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:chevron-left"></iconify-icon>
 {/snippet}
 
 <CalendarPrimitive.PrevButton

--- a/libraries/ui/src/shadcn/components/ui/carousel/carousel-next.svelte
+++ b/libraries/ui/src/shadcn/components/ui/carousel/carousel-next.svelte
@@ -36,6 +36,6 @@ const emblaCtx = getEmblaContext('<Carousel.Next/>')
 	bind:ref
 	{...restProps}
 >
-	<iconify-icon height="16" icon="lucide:arrow-right" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:arrow-right"></iconify-icon>
 	<span class="sr-only">Next slide</span>
 </Button>

--- a/libraries/ui/src/shadcn/components/ui/carousel/carousel-previous.svelte
+++ b/libraries/ui/src/shadcn/components/ui/carousel/carousel-previous.svelte
@@ -36,6 +36,6 @@ const emblaCtx = getEmblaContext('<Carousel.Previous/>')
 	{...restProps}
 	bind:ref
 >
-	<iconify-icon height="16" icon="lucide:arrow-left" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:arrow-left"></iconify-icon>
 	<span class="sr-only">Previous slide</span>
 </Button>

--- a/libraries/ui/src/shadcn/components/ui/command/command-input.svelte
+++ b/libraries/ui/src/shadcn/components/ui/command/command-input.svelte
@@ -15,7 +15,7 @@ let {
 </script>
 
 <div class="flex h-9 items-center gap-2 border-b px-3" data-slot="command-input-wrapper">
-	<iconify-icon class="size-4 shrink-0 opacity-50" height="24" icon="lucide:search" width="24"
+	<iconify-icon class="size-4 shrink-0 opacity-50" icon="lucide:search"
 	></iconify-icon>
 	<CommandPrimitive.Input
 		class={cx(

--- a/libraries/ui/src/shadcn/components/ui/context-menu/context-menu-checkbox-item.svelte
+++ b/libraries/ui/src/shadcn/components/ui/context-menu/context-menu-checkbox-item.svelte
@@ -35,7 +35,7 @@ let {
 	{#snippet children({ checked })}
 		<span class="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
 			{#if checked}
-				<iconify-icon height="16" icon="lucide:check" width="16"></iconify-icon>
+				<iconify-icon icon="lucide:check"></iconify-icon>
 			{/if}
 		</span>
 		{@render childrenProp?.()}

--- a/libraries/ui/src/shadcn/components/ui/context-menu/context-menu-radio-item.svelte
+++ b/libraries/ui/src/shadcn/components/ui/context-menu/context-menu-radio-item.svelte
@@ -28,7 +28,7 @@ let {
 	{#snippet children({ checked })}
 		<span class="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
 			{#if checked}
-				<iconify-icon height="16" icon="lucide:circle" width="16"></iconify-icon>
+				<iconify-icon icon="lucide:circle"></iconify-icon>
 			{/if}
 		</span>
 		{@render childrenProp?.({ checked })}

--- a/libraries/ui/src/shadcn/components/ui/context-menu/context-menu-sub-trigger.svelte
+++ b/libraries/ui/src/shadcn/components/ui/context-menu/context-menu-sub-trigger.svelte
@@ -32,5 +32,5 @@ let {
 	{...restProps}
 >
 	{@render children?.()}
-	<iconify-icon height="16" icon="lucide:chevron-right" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:chevron-right"></iconify-icon>
 </ContextMenuPrimitive.SubTrigger>

--- a/libraries/ui/src/shadcn/components/ui/dialog/dialog-content.svelte
+++ b/libraries/ui/src/shadcn/components/ui/dialog/dialog-content.svelte
@@ -41,7 +41,7 @@ let {
 				disabled:pointer-events-none [&_iconify-icon:not([class*='size-'])]:size-4
 				[&_iconify-icon]:pointer-events-none [&_iconify-icon]:shrink-0"
 		>
-			<iconify-icon height="16" icon="lucide:x" width="16"></iconify-icon>
+			<iconify-icon icon="lucide:x"></iconify-icon>
 			<span class="sr-only">Close</span>
 		</DialogPrimitive.Close>
 	</DialogPrimitive.Content>

--- a/libraries/ui/src/shadcn/components/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
+++ b/libraries/ui/src/shadcn/components/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
@@ -35,9 +35,9 @@ let {
 	{#snippet children({ checked, indeterminate })}
 		<span class="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
 			{#if indeterminate}
-				<iconify-icon height="16" icon="lucide:minus" width="16"></iconify-icon>
+				<iconify-icon icon="lucide:minus"></iconify-icon>
 			{:else if checked}
-				<iconify-icon height="16" icon="lucide:check" width="16"></iconify-icon>
+				<iconify-icon icon="lucide:check"></iconify-icon>
 			{/if}
 		</span>
 		{@render childrenProp?.()}

--- a/libraries/ui/src/shadcn/components/ui/dropdown-menu/dropdown-menu-radio-item.svelte
+++ b/libraries/ui/src/shadcn/components/ui/dropdown-menu/dropdown-menu-radio-item.svelte
@@ -28,7 +28,7 @@ let {
 	{#snippet children({ checked })}
 		<span class="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
 			{#if checked}
-				<iconify-icon height="16" icon="lucide:circle" width="16"></iconify-icon>
+				<iconify-icon icon="lucide:circle"></iconify-icon>
 			{/if}
 		</span>
 		{@render childrenProp?.({ checked })}

--- a/libraries/ui/src/shadcn/components/ui/dropdown-menu/dropdown-menu-sub-trigger.svelte
+++ b/libraries/ui/src/shadcn/components/ui/dropdown-menu/dropdown-menu-sub-trigger.svelte
@@ -32,5 +32,5 @@ let {
 	{...restProps}
 >
 	{@render children?.()}
-	<iconify-icon height="16" icon="lucide:chevron-right" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:chevron-right"></iconify-icon>
 </DropdownMenuPrimitive.SubTrigger>

--- a/libraries/ui/src/shadcn/components/ui/input-otp/input-otp-separator.svelte
+++ b/libraries/ui/src/shadcn/components/ui/input-otp/input-otp-separator.svelte
@@ -16,6 +16,6 @@ let {
 	{#if children}
 		{@render children?.()}
 	{:else}
-		<iconify-icon height="16" icon="lucide:dot" width="16"></iconify-icon>
+		<iconify-icon icon="lucide:dot"></iconify-icon>
 	{/if}
 </div>

--- a/libraries/ui/src/shadcn/components/ui/menubar/menubar-checkbox-item.svelte
+++ b/libraries/ui/src/shadcn/components/ui/menubar/menubar-checkbox-item.svelte
@@ -35,9 +35,9 @@ let {
 	{#snippet children({ checked, indeterminate })}
 		<span class="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
 			{#if indeterminate}
-				<iconify-icon height="16" icon="lucide:minus" width="16"></iconify-icon>
+				<iconify-icon icon="lucide:minus"></iconify-icon>
 			{:else if checked}
-				<iconify-icon height="16" icon="lucide:check" width="16"></iconify-icon>
+				<iconify-icon icon="lucide:check"></iconify-icon>
 			{/if}
 		</span>
 		{@render childrenProp?.()}

--- a/libraries/ui/src/shadcn/components/ui/menubar/menubar-radio-item.svelte
+++ b/libraries/ui/src/shadcn/components/ui/menubar/menubar-radio-item.svelte
@@ -28,7 +28,7 @@ let {
 	{#snippet children({ checked })}
 		<span class="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
 			{#if checked}
-				<iconify-icon height="16" icon="lucide:circle" width="16"></iconify-icon>
+				<iconify-icon icon="lucide:circle"></iconify-icon>
 			{/if}
 		</span>
 		{@render childrenProp?.({ checked })}

--- a/libraries/ui/src/shadcn/components/ui/menubar/menubar-sub-trigger.svelte
+++ b/libraries/ui/src/shadcn/components/ui/menubar/menubar-sub-trigger.svelte
@@ -29,5 +29,5 @@ let {
 	{...restProps}
 >
 	{@render children?.()}
-	<iconify-icon height="16" icon="lucide:chevron-right" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:chevron-right"></iconify-icon>
 </MenubarPrimitive.SubTrigger>

--- a/libraries/ui/src/shadcn/components/ui/navigation-menu/navigation-menu-trigger.svelte
+++ b/libraries/ui/src/shadcn/components/ui/navigation-menu/navigation-menu-trigger.svelte
@@ -29,5 +29,5 @@ let {
 >
 	{@render children?.()}
 
-	<iconify-icon height="16" icon="lucide:chevron-down" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:chevron-down"></iconify-icon>
 </NavigationMenuPrimitive.Trigger>

--- a/libraries/ui/src/shadcn/components/ui/pagination/pagination-ellipsis.svelte
+++ b/libraries/ui/src/shadcn/components/ui/pagination/pagination-ellipsis.svelte
@@ -19,6 +19,6 @@ let {
 	data-slot="pagination-ellipsis"
 	{...restProps}
 >
-	<iconify-icon height="16" icon="lucide:more-horizontal" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:more-horizontal"></iconify-icon>
 	<span class="sr-only">More pages</span>
 </span>

--- a/libraries/ui/src/shadcn/components/ui/pagination/pagination-next-button.svelte
+++ b/libraries/ui/src/shadcn/components/ui/pagination/pagination-next-button.svelte
@@ -16,7 +16,7 @@ let {
 
 {#snippet Fallback()}
 	<span>Next</span>
-	<iconify-icon height="16" icon="lucide:chevron-right" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:chevron-right"></iconify-icon>
 {/snippet}
 
 <PaginationPrimitive.NextButton

--- a/libraries/ui/src/shadcn/components/ui/pagination/pagination-prev-button.svelte
+++ b/libraries/ui/src/shadcn/components/ui/pagination/pagination-prev-button.svelte
@@ -15,7 +15,7 @@ let {
 </script>
 
 {#snippet Fallback()}
-	<iconify-icon height="16" icon="lucide:chevron-left" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:chevron-left"></iconify-icon>
 	<span>Previous</span>
 {/snippet}
 

--- a/libraries/ui/src/shadcn/components/ui/radio-group/radio-group-item.svelte
+++ b/libraries/ui/src/shadcn/components/ui/radio-group/radio-group-item.svelte
@@ -28,7 +28,7 @@ let {
 	{#snippet children({ checked })}
 		<div class="relative flex items-center justify-center" data-slot="radio-group-indicator">
 			{#if checked}
-				<iconify-icon height="16" icon="lucide:circle" width="16"></iconify-icon>
+				<iconify-icon icon="lucide:circle"></iconify-icon>
 			{/if}
 		</div>
 	{/snippet}

--- a/libraries/ui/src/shadcn/components/ui/range-calendar/range-calendar-next-button.svelte
+++ b/libraries/ui/src/shadcn/components/ui/range-calendar/range-calendar-next-button.svelte
@@ -15,7 +15,7 @@ let {
 </script>
 
 {#snippet Fallback()}
-	<iconify-icon height="16" icon="lucide:chevron-right" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:chevron-right"></iconify-icon>
 {/snippet}
 
 <RangeCalendarPrimitive.NextButton

--- a/libraries/ui/src/shadcn/components/ui/range-calendar/range-calendar-prev-button.svelte
+++ b/libraries/ui/src/shadcn/components/ui/range-calendar/range-calendar-prev-button.svelte
@@ -15,7 +15,7 @@ let {
 </script>
 
 {#snippet Fallback()}
-	<iconify-icon height="16" icon="lucide:chevron-left" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:chevron-left"></iconify-icon>
 {/snippet}
 
 <RangeCalendarPrimitive.PrevButton

--- a/libraries/ui/src/shadcn/components/ui/resizable/resizable-handle.svelte
+++ b/libraries/ui/src/shadcn/components/ui/resizable/resizable-handle.svelte
@@ -32,7 +32,7 @@ let {
 >
 	{#if withHandle}
 		<div class="bg-border rounded-xs z-10 flex h-4 w-3 items-center justify-center border">
-			<iconify-icon height="16" icon="lucide:grip-vertical" width="16"></iconify-icon>
+			<iconify-icon icon="lucide:grip-vertical"></iconify-icon>
 		</div>
 	{/if}
 </ResizablePrimitive.PaneResizer>

--- a/libraries/ui/src/shadcn/components/ui/select/select-item.svelte
+++ b/libraries/ui/src/shadcn/components/ui/select/select-item.svelte
@@ -33,7 +33,7 @@ let {
 	{#snippet children({ selected, highlighted })}
 		<span class="absolute right-2 flex size-3.5 items-center justify-center">
 			{#if selected}
-				<iconify-icon height="16" icon="lucide:check" width="16"></iconify-icon>
+				<iconify-icon icon="lucide:check"></iconify-icon>
 			{/if}
 		</span>
 		{#if childrenProp}

--- a/libraries/ui/src/shadcn/components/ui/select/select-scroll-down-button.svelte
+++ b/libraries/ui/src/shadcn/components/ui/select/select-scroll-down-button.svelte
@@ -18,5 +18,5 @@ let {
 	bind:ref
 	{...restProps}
 >
-	<iconify-icon height="16" icon="lucide:chevron-down" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:chevron-down"></iconify-icon>
 </SelectPrimitive.ScrollDownButton>

--- a/libraries/ui/src/shadcn/components/ui/select/select-scroll-up-button.svelte
+++ b/libraries/ui/src/shadcn/components/ui/select/select-scroll-up-button.svelte
@@ -18,5 +18,5 @@ let {
 	bind:ref
 	{...restProps}
 >
-	<iconify-icon height="16" icon="lucide:chevron-up" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:chevron-up"></iconify-icon>
 </SelectPrimitive.ScrollUpButton>

--- a/libraries/ui/src/shadcn/components/ui/select/select-trigger.svelte
+++ b/libraries/ui/src/shadcn/components/ui/select/select-trigger.svelte
@@ -36,5 +36,5 @@ let {
 	{...restProps}
 >
 	{@render children?.()}
-	<iconify-icon style="opacity: 0.5;" height="16" icon="lucide:chevron-down" width="16"></iconify-icon>
+	<iconify-icon style="opacity: 0.5;" icon="lucide:chevron-down"></iconify-icon>
 </SelectPrimitive.Trigger>

--- a/libraries/ui/src/shadcn/components/ui/sheet/sheet-content.svelte
+++ b/libraries/ui/src/shadcn/components/ui/sheet/sheet-content.svelte
@@ -58,7 +58,7 @@ let {
 				right-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2
 				focus-visible:ring-offset-2 disabled:pointer-events-none"
 		>
-			<iconify-icon height="16" icon="lucide:x" width="16"></iconify-icon>
+			<iconify-icon icon="lucide:x"></iconify-icon>
 			<span class="sr-only">Close</span>
 		</SheetPrimitive.Close>
 	</SheetPrimitive.Content>

--- a/libraries/ui/src/shadcn/components/ui/sidebar/sidebar-trigger.svelte
+++ b/libraries/ui/src/shadcn/components/ui/sidebar/sidebar-trigger.svelte
@@ -33,6 +33,6 @@ const sidebar = useSidebar()
 	variant="ghost"
 	{...restProps}
 >
-	<iconify-icon height="16" icon="lucide:panel-left" width="16"></iconify-icon>
+	<iconify-icon icon="lucide:panel-left"></iconify-icon>
 	<span class="sr-only">Toggle Sidebar</span>
 </Button>


### PR DESCRIPTION
iconify-icon 컴포넌트 내에서 height와 width 속성을 제거하고 기본 크기 사용으로 변경함.  
이로 인해 코드가 간결해지고, 아이콘 크기 관리가 일관되게 개선됨.  
기능 변경 없이 스타일 관련 코드 정리 목적임.