### PR TITLE
test: fast-check 테스트 numRuns 및 sequenceLength 축소

### DIFF
--- a/storybook/e2e/fast-check.test.js
+++ b/storybook/e2e/fast-check.test.js
@@ -108,8 +108,8 @@ for (const entry of Object.values(manifest.entries)) {
 
 		await page.emulateMedia({ reducedMotion: 'reduce' })
 		const results = await testUIComponent(page, {
-			numRuns: 2,
-			sequenceLength: 5,
+			numRuns: 1,
+			sequenceLength: 1,
 			waitAfterInteraction: 50,
 			verbose: false,
 		})


### PR DESCRIPTION
fast-check 테스트에서 numRuns를 2에서 1로, sequenceLength를 5에서 1로 줄여 테스트 실행 시간을 
단축함. 테스트 효율성 향상 및 불필요한 반복 최소화를 위한 변경임.