### PR TITLE
feat(ci): GitHub Actions workflow 안정화 및 lint/format 처리 개선

### DIFF
--- a/.github/workflows/mutate_code.yml
+++ b/.github/workflows/mutate_code.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: 라벨 제거
         if: github.event.label.name == 'restart'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.TOKEN1 }}
           script: |
@@ -106,22 +106,22 @@ jobs:
               - 'libraries/**'
               - 'storybook/**'
             images:
-              - '**.jpg'
-              - '**.jpeg'
-              - '**.png'
-              - '**.webp'
-              - '**.gif'
-              - '**.svg'
-              - '**.pdf'
-              - '**.tiff'
-              - '**.magick'
-              - '**.openslide'
-              - '**.dz'
-              - '**.ppm'
-              - '**.fits'
-              - '**.heif'
-              - '**.vips'
-              - '**.raw'
+              - '**/**.jpg'
+              - '**/**.jpeg'
+              - '**/**.png'
+              - '**/**.webp'
+              - '**/**.gif'
+              - '**/**.svg'
+              - '**/**.pdf'
+              - '**/**.tiff'
+              - '**/**.magick'
+              - '**/**.openslide'
+              - '**/**.dz'
+              - '**/**.ppm'
+              - '**/**.fits'
+              - '**/**.heif'
+              - '**/**.vips'
+              - '**/**.raw'
             markdown:
               - '**/*.md'
               - '**/*.mdx'
@@ -144,7 +144,7 @@ jobs:
       - name: 저장소 체크아웃
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.TOKEN1 }}
           fetch-depth: 0
 
@@ -202,14 +202,14 @@ jobs:
       - name: 저장소 체크아웃
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.TOKEN1 }}
           fetch-depth: 0
 
       # 1. package-json 패치 다운로드
       - name: package-json 패치 존재 여부 확인
         id: check_package_json_patch_fix_md
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -308,13 +308,22 @@ jobs:
       - name: 마크다운 파일 Lint 및 포맷 수정
         if: steps.changed-markdown-files.outputs.all_changed_files != ''
         run: |
-          MODIFIED_FILES="${{ steps.changed-markdown-files.outputs.all_changed_files }}"
+          # 변경된 마크다운 파일을 널(\0) 구분으로 안전하게 수집
+          mapfile -d '' MDFILES < <(git status --porcelain=v1 -z | awk -v RS='\0' '/\.md$|\.mdx$|\.mdc$/ {print $0}' | cut -c 4- | tr '\n' '\0')
+
+          if [ ${#MDFILES[@]} -eq 0 ]; then
+            echo "변경된 마크다운 파일 없음"
+            exit 0
+          fi
+
           echo "ESLint"
-          pnpm exec eslint --fix $MODIFIED_FILES
+          printf '%s\0' "${MDFILES[@]}" | xargs -0 -r pnpm exec eslint --fix
+
           echo "Stylelint"
-          pnpm exec stylelint --fix --allow-empty-input $MODIFIED_FILES
+          printf '%s\0' "${MDFILES[@]}" | xargs -0 -r pnpm exec stylelint --fix --allow-empty-input
+
           echo "Prettier"
-          pnpm exec prettier --write --ignore-unknown --ignore-path .prettierignore $MODIFIED_FILES
+          printf '%s\0' "${MDFILES[@]}" | xargs -0 -r pnpm exec prettier --write --ignore-unknown --ignore-path .prettierignore
         continue-on-error: true
 
       # 8. 마크다운 변경사항 패치 생성 (임시 커밋 기준)
@@ -358,14 +367,14 @@ jobs:
       - name: 저장소 체크아웃
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.TOKEN1 }}
           fetch-depth: 0
 
       # 1. package-json 패치 다운로드
       - name: package-json 패치 존재 여부 확인
         id: check_package_json_patch
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -409,7 +418,7 @@ jobs:
       # 5. markdown patch 다운로드
       - name: 마크다운 패치 존재 여부 확인
         id: check_markdown_patch_lint_format
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -597,14 +606,14 @@ jobs:
       - name: 저장소 체크아웃
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.TOKEN1 }} # 필요시 토큰 사용
           fetch-depth: 0 # diff를 위해
 
       # 1. package-json 패치 다운로드
       - name: package-json 패치 존재 여부 확인
         id: check_package_json_patch_lint_format
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -645,7 +654,7 @@ jobs:
       # 5. markdown patch 다운로드
       - name: 마크다운 패치 존재 여부 확인
         id: check_markdown_patch_lint_format
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -686,7 +695,7 @@ jobs:
       # 3. translation patch 다운로드
       - name: 번역 패치 존재 여부 확인
         id: check_translation_patch_lint_format
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -767,21 +776,40 @@ jobs:
       - name: 린트 및 포맷 실행
         if: steps.changed-files.outputs.all_changed_files != ''
         run: |
-          MODIFIED_FILES="${{ steps.changed-files.outputs.all_changed_files }}"
-          echo "ESLint"
-          pnpm exec eslint --fix $MODIFIED_FILES
-          echo "Stylelint"
-          # Stylelint는 CSS, Svelte 파일 내의 스타일을 처리합니다.
-          STYLELINT_FILES=$(echo "$MODIFIED_FILES" | tr ' ' '\n' | grep -E '\.(css|svelte|md|mdx|mdc)$' | tr '\n' ' ' | sed 's/ $//')
-          if [ -n "$STYLELINT_FILES" ]; then
-            echo "Stylelint를 실행할 파일 목록:"
-            echo "$STYLELINT_FILES"
-            pnpm exec stylelint --fix --allow-empty-input $STYLELINT_FILES
-          else
-            echo "Stylelint를 실행할 파일이 없습니다."
+          # 임시 커밋(HEAD) 대비 변경 파일 목록을 널(\0) 구분으로 획득
+          mapfile -d '' FILES < <(git diff --name-only -z HEAD)
+
+          # 마크다운 제외(이미 별도 단계에서 처리)
+          files_no_md=()
+          for f in "${FILES[@]}"; do
+            case "$f" in
+              *.md|*.mdx|*.mdc) continue;;
+              *) files_no_md+=("$f");;
+            esac
+          done
+
+          # 마지막 변경 커밋이 [automated-mutation]인 파일 제외
+          filtered=()
+          for f in "${files_no_md[@]}"; do
+            if git log -1 --pretty=%B -- "$f" | grep -q '\[automated-mutation\]'; then
+              continue
+            fi
+            filtered+=("$f")
+          done
+
+          if [ ${#filtered[@]} -eq 0 ]; then
+            echo "대상 파일 없음(자동수정만 있었거나 마크다운만 변경). 린트/포맷 생략."
+            exit 0
           fi
+
+          echo "ESLint"
+          printf '%s\0' "${filtered[@]}" | xargs -0 -r pnpm exec eslint --fix
+
+          echo "Stylelint"
+          printf '%s\0' "${filtered[@]}" | grep -z -E '\.(css|svelte|md|mdx|mdc)$' | xargs -0 -r pnpm exec stylelint --fix --allow-empty-input
+
           echo "Prettier"
-          pnpm exec prettier --write --ignore-unknown --ignore-path .prettierignore $MODIFIED_FILES
+          printf '%s\0' "${filtered[@]}" | xargs -0 -r pnpm exec prettier --write --ignore-unknown --ignore-path .prettierignore
         continue-on-error: true
 
       # changes.patch 생성 (임시 커밋 기준) 및 변경 유무 출력
@@ -824,7 +852,7 @@ jobs:
       - name: 저장소 체크아웃
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.TOKEN1 }}
           fetch-depth: 0
 
@@ -871,7 +899,7 @@ jobs:
 
       - name: package-json 패치 존재 여부 확인
         id: check_package_json_patch_push
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -890,7 +918,7 @@ jobs:
 
       - name: 마크다운 패치 존재 여부 확인
         id: check_markdown_patch_push
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -912,7 +940,7 @@ jobs:
 
       - name: 번역 패치 존재 여부 확인
         id: check_translation_patch_push
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -934,7 +962,7 @@ jobs:
 
       - name: changes.patch (린트/포맷) 존재 여부 확인
         id: check_changes_patch_push
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -956,7 +984,7 @@ jobs:
 
       - name: 이미지 패치 존재 여부 확인
         id: check_images_patch_push
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -1057,7 +1085,7 @@ jobs:
       # Add a Label to PR 1
       - name: PR에 라벨 추가 1 (mutated)
         if: steps.auto-commit.outputs.changes_detected == 'true'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.TOKEN1 }}
           script: |


### PR DESCRIPTION
워크플로우에서 actions/github-script 버전 v6 → v로 업데이트하여 호환성 개선.
이미지 패턴을.ext'에서 '**/**.ext'로 변경하여 하위 디렉토리의 파일 탐지 보장.
checkout 동작을 ref: ${{ github.head_ref }}에서 PR 실제 커밋인 ${{ github.event.pull_request.head.sha }}로 변경하여 정확한 체크아웃 보장.
마크다운 및 일반 파일 대상의 lint/format 스텝을 null-안전한 처리(널 구분, mapfile, xargs -0)로 개선하여 파일명에 공백/특수문자가 있어도 안전하게 실행되도록 수정.
lint/format 대상 필터링 추가: 마크다운은 전용 단계에서 처리하고, 마지막 커밋 메시지에 [automated-mutation]이 포함된 파일은 건너뛰도록 하여 불필요한 재처리 방지.
전반적인 스크립트 안정성 및 파일 선택 로직 개선으로 CI 실패 및 오작동 감소 목적

변경의 핵심은 workflow 안정화 및 lint/format 처리의 안전성 확보임.