### PR TITLE
feat(env): dotenv 및 supabase 클라이언트 추가

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-pnpm install

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -5,12 +5,11 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build",
-		"build:dotenv": "dotenv -e ../../.env vite build",
 		"build:en": "vite build",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --no-tsconfig --ignore ../../libraries",
 		"check:watch": "pnpm run check -- --watch",
 		"depCheck": "npx depcheck",
-		"dev": "dotenv -e ../../.env vite dev",
+		"dev": "vite dev",
 		"eslint": "eslint . --ignore-pattern **/*.md --ignore-pattern **/*.mdx",
 		"eslint-fix": "eslint --fix . || true",
 		"format": "prettier . \"!**/*.md\" \"!**/*.mdx\" --write --ignore-unknown --ignore-path ../../.prettierignore",
@@ -21,10 +20,9 @@
 		"test:e2e": "pnpm exec playwright test",
 		"test:unit": "vitest run",
 		"translate": "node ./src/translation/scripts.js",
-		"translate:dotenv": "dotenv -e ../../.env node ./src/translation/scripts.js",
+		"translate:dotenv": "node --env-file=../../.env ./src/translation/scripts.js",
 		"type-sync": "svelte-kit sync",
 		"preview": "vite preview",
-		"previewWithDotenv": "dotenv -e ../../.env vite preview",
 		"watch:dev": "turbo run dev --filter={./} --filter=@tool/storybook --output-logs=new-only"
 	},
 	"dependencies": {

--- a/apps/boiler_plates/package.json
+++ b/apps/boiler_plates/package.json
@@ -5,12 +5,11 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build",
-		"build:dotenv": "dotenv -e ../../.env vite build",
 		"build:en": "vite build",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --no-tsconfig --ignore ../../libraries",
 		"check:watch": "pnpm run check -- --watch",
 		"depCheck": "npx depcheck",
-		"dev": "dotenv -e ../../.env vite dev",
+		"dev": "vite dev",
 		"eslint": "eslint . --ignore-pattern **/*.md --ignore-pattern **/*.mdx",
 		"eslint-fix": "eslint --fix . || true",
 		"format": "prettier . \"!**/*.md\" \"!**/*.mdx\" --write --ignore-unknown --ignore-path ../../.prettierignore",
@@ -21,10 +20,9 @@
 		"test:e2e": "pnpm exec playwright test",
 		"test:unit": "vitest run",
 		"translate": "node ./src/translation/scripts.js",
-		"translate:dotenv": "dotenv -e ../../.env node ./src/translation/scripts.js",
+		"translate:dotenv": "node --env-file=../../.env ./src/translation/scripts.js",
 		"type-sync": "svelte-kit sync",
 		"preview": "vite preview",
-		"previewWithDotenv": "dotenv -e ../../.env vite preview",
 		"watch:dev": "turbo run dev --filter={./} --filter=@tool/storybook --output-logs=new-only"
 	},
 	"dependencies": {

--- a/libraries/base/vite.config.js
+++ b/libraries/base/vite.config.js
@@ -20,6 +20,7 @@ if (process.env.CF_PAGES_BRANCH === 'main' || process.env.CF_PAGES_BRANCH === 'p
 }
 
 const baseConfig = defineConfig({
+	envDir: '../../',
 	build: {
 		sourcemap: currentEnv === 'development' ? true : 'hidden', // Sentry 설정에서 sourcemap 파일 지움
 		cssMinify: 'lightningcss',

--- a/libraries/paraglide/package.json
+++ b/libraries/paraglide/package.json
@@ -16,7 +16,7 @@
 		"build:en": "pnpm run change-base-locale:en && pnpm run build",
 		"translate": "pnpm run check-no-missing-explanations && node ./src/translation.js",
 		"translate-machine": "npx @inlang/cli machine translate --project ./project.inlang",
-		"translate:dotenv": "dotenv -e ../../.env node ./src/translation.js"
+		"translate:dotenv": "node --env-file=../../.env ./src/translation.js"
 	},
 	"dependencies": {
 		"@library/helpers": "workspace:*",

--- a/libraries/scripts/package.json
+++ b/libraries/scripts/package.json
@@ -15,6 +15,7 @@
 		"@library/helpers": "workspace:*",
 		"@library/library-base": "workspace:*",
 		"@library/llms": "workspace:*",
+		"@supabase/supabase-js": "^2.54.0",
 		"ai": "^4.3.9",
 		"zod": "^3.25.36"
 	},

--- a/libraries/scripts/src/supabase.js
+++ b/libraries/scripts/src/supabase.js
@@ -1,0 +1,3 @@
+import { createClient } from '@supabase/supabase-js'
+
+export const supabase = createClient(String(process.env.VITE_PUBLIC_SUPABASE_URL), String(process.env.VITE_PUBLIC_SUPABASE_ANON_KEY))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -644,6 +644,9 @@ importers:
       '@library/llms':
         specifier: workspace:*
         version: link:../llms
+      '@supabase/supabase-js':
+        specifier: ^2.54.0
+        version: 2.54.0
       ai:
         specifier: ^4.3.9
         version: 4.3.13(react@19.1.0)(zod@3.25.36)
@@ -3144,6 +3147,28 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
+  '@supabase/auth-js@2.71.1':
+    resolution: {integrity: sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==}
+
+  '@supabase/functions-js@2.4.5':
+    resolution: {integrity: sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==}
+
+  '@supabase/node-fetch@2.6.15':
+    resolution: {integrity: sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==}
+    engines: {node: 4.x || >=6.0.0}
+
+  '@supabase/postgrest-js@1.19.4':
+    resolution: {integrity: sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==}
+
+  '@supabase/realtime-js@2.15.0':
+    resolution: {integrity: sha512-SEIWApsxyoAe68WU2/5PCCuBwa11LL4Bb8K3r2FHCt3ROpaTthmDiWEhnLMGayP05N4QeYrMk0kyTZOwid/Hjw==}
+
+  '@supabase/storage-js@2.10.4':
+    resolution: {integrity: sha512-cvL02GarJVFcNoWe36VBybQqTVRq6wQSOCvTS64C+eyuxOruFIm1utZAY0xi2qKtHJO3EjKaj8iWJKySusDmAQ==}
+
+  '@supabase/supabase-js@2.54.0':
+    resolution: {integrity: sha512-DLw83YwBfAaFiL3oWV26+sHRdeCGtxmIKccjh/Pndze3BWM4fZghzYKhk3ElOQU8Bluq4AkkCJ5bM5Szl/sfRg==}
+
   '@sveltejs/acorn-typescript@1.0.5':
     resolution: {integrity: sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==}
     peerDependencies:
@@ -3599,6 +3624,9 @@ packages:
   '@types/pg@8.6.1':
     resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
 
+  '@types/phoenix@1.6.6':
+    resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
+
   '@types/pug@2.0.10':
     resolution: {integrity: sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==}
 
@@ -3628,6 +3656,9 @@ packages:
 
   '@types/validator@13.12.3':
     resolution: {integrity: sha512-2ipwZ2NydGQJImne+FhNdhgRM37e9lCev99KnqkbFHd94Xn/mErARWI1RSLem1QA19ch5kOhzIZd7e8CA2FI8g==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typeschema/class-validator@0.3.0':
     resolution: {integrity: sha512-OJSFeZDIQ8EK1HTljKLT5CItM2wsbgczLN8tMEfz3I1Lmhc5TBfkZ0eikFzUC16tI3d1Nag7um6TfCgp2I2Bww==}
@@ -12934,6 +12965,48 @@ snapshots:
     dependencies:
       storybook: 8.6.12(prettier@3.5.3)
 
+  '@supabase/auth-js@2.71.1':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/functions-js@2.4.5':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/node-fetch@2.6.15':
+    dependencies:
+      whatwg-url: 5.0.0
+
+  '@supabase/postgrest-js@1.19.4':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/realtime-js@2.15.0':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+      '@types/phoenix': 1.6.6
+      '@types/ws': 8.18.1
+      ws: 8.18.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.10.4':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/supabase-js@2.54.0':
+    dependencies:
+      '@supabase/auth-js': 2.71.1
+      '@supabase/functions-js': 2.4.5
+      '@supabase/node-fetch': 2.6.15
+      '@supabase/postgrest-js': 1.19.4
+      '@supabase/realtime-js': 2.15.0
+      '@supabase/storage-js': 2.10.4
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@sveltejs/acorn-typescript@1.0.5(acorn@8.15.0)':
     dependencies:
       acorn: 8.15.0
@@ -13396,6 +13469,8 @@ snapshots:
       pg-protocol: 1.8.0
       pg-types: 2.2.0
 
+  '@types/phoenix@1.6.6': {}
+
   '@types/pug@2.0.10': {}
 
   '@types/react@19.1.1':
@@ -13421,6 +13496,10 @@ snapshots:
 
   '@types/validator@13.12.3':
     optional: true
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.14.1
 
   '@typeschema/class-validator@0.3.0(@types/json-schema@7.0.15)(class-validator@0.14.1)':
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,10 @@
 	"globalDependencies": [],
 	"globalEnv": ["NODE_ENV", "CF_PAGES_BRANCH"],
 	"globalPassThroughEnv": [
+		"MAILGUN",
+		"MAILGUN_SENDING",
+		"VITE_PUBLIC_SUPABASE_URL",
+		"VITE_PUBLIC_SUPABASE_ANON_KEY",
 		"GEMINI_API_KEY",
 		"GOOGLE_GENERATIVE_AI_API_KEY",
 		"CI",


### PR DESCRIPTION
- package.json 스립트에서 dotenv 및 node --env-file 사용으로 환경수 로드 방식 통일
- apps/blog, apps/iler_, libraries/paraglide의 dev/preview/build 스크립트 간소화 및 translate 스크립트의 env 로드 방식
- vite base config에 envDir 설정 추가하여 프로젝트 루트 .env 경로 지정
- turbo.json에 VITE_PUBLIC_SUPABASE_* 및 MAILGUN 관련 환경변수 추가로 글로벌 env 전달 설정 확장
- libraries/scripts에 Supabase 클라이언트(@supabase/supabase-js) 코드 및 의존성 추가하여 Supabase 연동 기반 마련
- pnpm-lock.yaml에 supabase 관련 패키지 및 타입/의존성 잠금 정보 추가
- .husky/pre-commit 파일의 불필요한 pnpm install 내용 제거