### PR TITLE
fix(supabase): NODE_ENV 검증으로 비밀 노출 차단함

### DIFF
--- a/libraries/backends/src/supabase/index.admin.js
+++ b/libraries/backends/src/supabase/index.admin.js
@@ -1,2 +1,6 @@
+if (process.env.NODE_ENV) {
+	throw new Error('비밀 노출')
+}
+
 export * from './init.admin.js'
 export * from './markdowns.admin.js'


### PR DESCRIPTION
librariesends/src/supabase/index.admin.js에서 process.env.NODE_ENV가 설정된 경우 예외를 던져 비밀 노출을 차단함. 추가로 init.admin.js와 markdowns.admin.js를 정상적으로 export하도록 유지함.