### PR TITLE
feat(ui): Link 컴포넌트에 custom class 병합 및 link snippet 도입

### DIFF
--- a/apps/blog/src/lib/components/postList.svelte
+++ b/apps/blog/src/lib/components/postList.svelte
@@ -15,7 +15,9 @@ let { allMetadata } = $props()
 	style:inline-size="100%"
 >
 	{#each allMetadata as postMetadata (postMetadata.slug)}
-		<Link
+		<div style="display: flex;">
+			{#snippet link()}
+			<Link
 			class={css`
 				display: block;
 				inline-size: fit-content;
@@ -23,19 +25,23 @@ let { allMetadata } = $props()
 			active={postMetadata.current}
 			href={`/posts/${postMetadata.slug}`}
 		>
-			{#if postMetadata.current}
-				<IconText iconName="mdi:chevron-right">
-					{postMetadata.title}
-				</IconText>
-			{:else if postMetadata.visited}
-				<IconText iconName="mdi:check">
-					{postMetadata.title}
-				</IconText>
-			{:else}
-				<IconText>
-					{postMetadata.title}
-				</IconText>
-			{/if}
+			{postMetadata.title}
 		</Link>
+		{/snippet}
+
+		{#if postMetadata.current}
+		<IconText iconName="mdi:chevron-right">
+			{@render link()}
+		</IconText>
+	{:else if postMetadata.visited}
+		<IconText iconName="mdi:check">
+			{@render link()}
+		</IconText>
+	{:else}
+		<IconText>
+			{@render link()}
+		</IconText>
+	{/if}
+		</div>
 	{/each}
 </div>

--- a/apps/blog/src/lib/components/postList.svelte
+++ b/apps/blog/src/lib/components/postList.svelte
@@ -15,33 +15,33 @@ let { allMetadata } = $props()
 	style:inline-size="100%"
 >
 	{#each allMetadata as postMetadata (postMetadata.slug)}
-		<div style="display: flex;">
+		<div style:display="flex">
 			{#snippet link()}
-			<Link
-			class={css`
-				display: block;
-				inline-size: fit-content;
-			`}
-			active={postMetadata.current}
-			href={`/posts/${postMetadata.slug}`}
-		>
-			{postMetadata.title}
-		</Link>
-		{/snippet}
+				<Link
+					class={css`
+						display: block;
+						inline-size: fit-content;
+					`}
+					active={postMetadata.current}
+					href={`/posts/${postMetadata.slug}`}
+				>
+					{postMetadata.title}
+				</Link>
+			{/snippet}
 
-		{#if postMetadata.current}
-		<IconText iconName="mdi:chevron-right">
-			{@render link()}
-		</IconText>
-	{:else if postMetadata.visited}
-		<IconText iconName="mdi:check">
-			{@render link()}
-		</IconText>
-	{:else}
-		<IconText>
-			{@render link()}
-		</IconText>
-	{/if}
+			{#if postMetadata.current}
+				<IconText iconName="mdi:chevron-right">
+					{@render link()}
+				</IconText>
+			{:else if postMetadata.visited}
+				<IconText iconName="mdi:check">
+					{@render link()}
+				</IconText>
+			{:else}
+				<IconText>
+					{@render link()}
+				</IconText>
+			{/if}
 		</div>
 	{/each}
 </div>

--- a/libraries/ui/src/miscellaneous/link.svelte
+++ b/libraries/ui/src/miscellaneous/link.svelte
@@ -1,5 +1,5 @@
 <script module>
-import { css } from '@emotion/css'
+import { css, cx } from '@emotion/css'
 import { localizeHref } from '@library/paraglide/helpers'
 import IconText from '@library/ui/icon-text'
 
@@ -16,21 +16,21 @@ const linkStyle = css`
 </script>
 
 <script>
-let { children, href = '', ...rest } = $props()
+let { children, class: incomingClass = '', href = '', ...rest } = $props()
 
 let isHeadingLink = $derived(href.startsWith('#'))
 let isInternalLink = $derived(href?.startsWith('.') || href?.startsWith('/'))
 </script>
 
 {#if isHeadingLink}
-	<a class={linkStyle} {href} {...rest}>
+	<a class={cx(linkStyle, incomingClass)} {href} {...rest}>
 		<IconText iconName="mdi:hashtag" noMargin right small>
 			{@render children?.()}
 		</IconText>
 	</a>
 {:else if isInternalLink}
 	<a
-		class={linkStyle}
+		class={cx(linkStyle, incomingClass)}
 		href={isInternalLink ? localizeHref(href) : href}
 		{...isInternalLink ? {} : newTabProperties}
 		{...rest}
@@ -41,7 +41,7 @@ let isInternalLink = $derived(href?.startsWith('.') || href?.startsWith('/'))
 	</a>
 {:else}
 	<a
-		class={linkStyle}
+		class={cx(linkStyle, incomingClass)}
 		href={isInternalLink ? localizeHref(href) : href}
 		{...isInternalLink ? {} : newTabProperties}
 		{...rest}


### PR DESCRIPTION
- @emotion/css의 cx 도입으로 incoming class와 linkStyle을 병합하도록 변경함
- Link 컴포넌트에 class prop 수용하도록 props 확장함
- blog postList에 link snippet 추가 및 기존 IconText 구조를 snippet 렌더 방식으로 재구성함
- 내부 링크에 대해 localizeHref 적용 유지 및 newTabProperties 처리 보존함