### PR TITLE
refactor(ui,,mic-alarm svelte 컴넌트 및 스타일 네이밍 정리

### DIFF
--- a/libraries/base/src/baseCSS.css
+++ b/libraries/base/src/baseCSS.css
@@ -4,7 +4,7 @@ html {
 	container: root / inline-size;
 	overflow: hidden;
 
-	block-size: 100dvb;
+	block-size: 100svb;
 
 	font-size: var(--font-size-fluid-0p6);
 	-webkit-font-smoothing: antialiased;

--- a/libraries/base/src/baseCSS.css
+++ b/libraries/base/src/baseCSS.css
@@ -4,7 +4,7 @@ html {
 	container: root / inline-size;
 	overflow: hidden;
 
-	block-size: 100svb;
+	block-size: 100dvb;
 
 	font-size: var(--font-size-fluid-0p6);
 	-webkit-font-smoothing: antialiased;

--- a/libraries/ui/src/markdown/blog/Markdown.svelte
+++ b/libraries/ui/src/markdown/blog/Markdown.svelte
@@ -53,8 +53,13 @@ const addedPlugins = [
 
 <script>
 import { setContext } from 'svelte'
+<<<<<<< ours
+||||||| ancestor
+import { page } from '$app/state'
+=======
 
 import { page } from '$app/state'
+>>>>>>> theirs
 
 let { mermaidSVGObject = {}, plugins = [], value } = $props()
 
@@ -75,7 +80,7 @@ $effect(() => {
 setContext('mermaidSVGObject', mermaidContext)
 
 function scheduleReanchor_action() {
-	const hash = (page?.url?.hash ?? '').slice(1)
+	const hash = typeof location === 'undefined' ? '' : location.hash.slice(1)
 	if (!hash) return
 	const id = decodeURIComponent(hash)
 	const target = typeof document === 'undefined' ? null : document.getElementById(id)

--- a/libraries/ui/src/markdown/blog/Markdown.svelte
+++ b/libraries/ui/src/markdown/blog/Markdown.svelte
@@ -53,13 +53,6 @@ const addedPlugins = [
 
 <script>
 import { setContext } from 'svelte'
-<<<<<<< ours
-||||||| ancestor
-import { page } from '$app/state'
-=======
-
-import { page } from '$app/state'
->>>>>>> theirs
 
 let { mermaidSVGObject = {}, plugins = [], value } = $props()
 

--- a/libraries/ui/src/markdown/blog/Markdown.svelte
+++ b/libraries/ui/src/markdown/blog/Markdown.svelte
@@ -53,6 +53,7 @@ const addedPlugins = [
 
 <script>
 import { setContext } from 'svelte'
+
 import { page } from '$app/state'
 
 let { mermaidSVGObject = {}, plugins = [], value } = $props()

--- a/libraries/ui/src/markdown/blog/Markdown.svelte
+++ b/libraries/ui/src/markdown/blog/Markdown.svelte
@@ -52,8 +52,8 @@ const addedPlugins = [
 </script>
 
 <script>
-import { idleRun_action } from '@library/helpers/functions'
-import { setContext, tick } from 'svelte'
+import { setContext } from 'svelte'
+import { page } from '$app/state'
 
 let { mermaidSVGObject = {}, plugins = [], value } = $props()
 
@@ -74,7 +74,7 @@ $effect(() => {
 setContext('mermaidSVGObject', mermaidContext)
 
 function scheduleReanchor_action() {
-	const hash = typeof location === 'undefined' ? '' : location.hash.slice(1)
+	const hash = (page?.url?.hash ?? '').slice(1)
 	if (!hash) return
 	const id = decodeURIComponent(hash)
 	const target = typeof document === 'undefined' ? null : document.getElementById(id)

--- a/tools/mic-alarm/src/routes/+page.svelte
+++ b/tools/mic-alarm/src/routes/+page.svelte
@@ -272,15 +272,15 @@ $effect(() => {
 })
 </script>
 
-<main class="container">
+<main class="container-div">
 	<h1 class="title">마이크 무음 경고</h1>
 
-	<section class="status">
-		<div class="row">
+	<section class="status-section">
+		<div class="row-div">
 			<div class="label">상태:</div>
 			<div class="value"><strong>{statusText}</strong></div>
 		</div>
-		<div class="row">
+		<div class="row-div">
 			<div class="label">현재 소리:</div>
 			<div class="value">
 				{#if isPaused}
@@ -292,7 +292,7 @@ $effect(() => {
 				{/if}
 			</div>
 		</div>
-		<div class="row">
+		<div class="row-div">
 			<div class="label">알람까지:</div>
 			<div class="value">
 				{#if isPaused}
@@ -304,7 +304,7 @@ $effect(() => {
 				{/if}
 			</div>
 		</div>
-		<div class="row">
+		<div class="row-div">
 			<div class="label">무음 경과:</div>
 			<div class="value">
 				{#if isPaused}
@@ -318,7 +318,7 @@ $effect(() => {
 		</div>
 	</section>
 
-	<section class="controls">
+	<section class="controls-section">
 		<div class="control">
 			<label for="thresholdDb">기준 소리 (dBFS)</label>
 			<input
@@ -414,11 +414,13 @@ $effect(() => {
 </main>
 
 <style>
-.container {
+.container-div {
 	max-inline-size: 780px;
 	margin: 0 auto;
 	padding: var(--space-l, 2rem);
 	color: var(--foreground, rgb(17 17 17));
+	height: 100vh;
+	overflow: auto;
 }
 
 .title {
@@ -426,7 +428,7 @@ $effect(() => {
 	font-size: clamp(1.5rem, 1rem + 2vi, 2.25rem);
 }
 
-.status {
+.status-section {
 	margin-block-end: var(--space-l, 2rem);
 	padding: var(--space-m, 1rem);
 	border: var(--border-size-1, 1px) solid var(--border, rgb(221 221 221));
@@ -435,7 +437,7 @@ $effect(() => {
 	background: var(--card, rgb(255 255 255));
 }
 
-.row {
+.row-div {
 	display: flex;
 	gap: 0.5rem;
 	align-items: center;
@@ -450,7 +452,7 @@ $effect(() => {
 	font-size: 1.125rem;
 }
 
-.controls {
+.controls-section {
 	display: grid;
 	gap: var(--space-m, 1rem);
 }

--- a/tools/mic-alarm/src/routes/+page.svelte
+++ b/tools/mic-alarm/src/routes/+page.svelte
@@ -415,12 +415,14 @@ $effect(() => {
 
 <style>
 .container-div {
+	overflow: auto;
+
 	max-inline-size: 780px;
+	block-size: 100vb;
 	margin: 0 auto;
 	padding: var(--space-l, 2rem);
+
 	color: var(--foreground, rgb(17 17 17));
-	height: 100vh;
-	overflow: auto;
 }
 
 .title {


### PR DESCRIPTION
- libraries/ui: Markdown.svelte에서 unused import 제거 및 client-safe하게 page.url.hash 사용으로 reanchor 로직 수정
- apps/blog: 여러 클래스명(container, status, row, controls)을 더 구체적인 이름(container-div, status-section, row-div, controls-section)으로 변경하고 레이아웃 높이/오버플로우 조정
- tools/mic-alarm: 스타일 마크업 네이밍 업데이트 반영

소규모 리팩토링으로 DOM 접근과 스타일 충돌을 완화함.